### PR TITLE
Mejoras: persistencia local, favicon/meta, health y webhook seguro

### DIFF
--- a/app/.env.example
+++ b/app/.env.example
@@ -23,3 +23,7 @@ ALERT_WHATSAPP_TO=whatsapp:+34640253466
 
 # --- Precios de skins por CSFloat (opcional; si no, usa Steam Market) ---
 CSFLOAT_API_KEY=
+
+# --- Seguridad del webhook entrante de WhatsApp (endpoint público) ---
+# Si lo defines, el webhook exige ?token=ESTE_VALOR para aceptar peticiones.
+WHATSAPP_WEBHOOK_TOKEN=

--- a/app/app.py
+++ b/app/app.py
@@ -79,6 +79,16 @@ def index():
     return render_template("index.html")
 
 
+@app.route("/health")
+def health():
+    return jsonify({"status": "ok"})
+
+
+@app.route("/favicon.ico")
+def favicon():
+    return app.send_static_file("favicon.svg")
+
+
 @app.route("/api/snapshots", methods=["GET"])
 def api_snapshots_get():
     """Histórico mensual de patrimonio: { 'YYYY-MM': { categoria: valor } }."""
@@ -244,9 +254,19 @@ def _twiml(message):
     return app.response_class(xml, mimetype="text/xml")
 
 
+def _webhook_authorized():
+    """Si WHATSAPP_WEBHOOK_TOKEN está definido, exige ?token=... (endpoint público)."""
+    expected = os.environ.get("WHATSAPP_WEBHOOK_TOKEN", "").strip()
+    if not expected:
+        return True
+    return request.args.get("token", "") == expected
+
+
 @app.route("/webhook/whatsapp", methods=["POST"])
 def whatsapp_inbound():
     """Webhook de Twilio: procesa PDFs/CSV adjuntos enviados por WhatsApp."""
+    if not _webhook_authorized():
+        return _twiml("No autorizado."), 403
     try:
         num_media = int(request.form.get("NumMedia", "0"))
     except ValueError:

--- a/app/static/app.js
+++ b/app/static/app.js
@@ -13,15 +13,27 @@ let BANK_NET = null;        // gasto neto del mes (informativo, no patrimonio)
 
 const thisMonth = () => new Date().toISOString().slice(0, 7);   // YYYY-MM
 
+// Persistencia local: sobrevive a los reinicios del hosting gratuito (Render free
+// no tiene disco), así el histórico mensual y el último estado no se pierden.
+const LS = {
+  snaps() { try { return JSON.parse(localStorage.getItem("mp_snapshots") || "{}"); } catch (e) { return {}; } },
+  saveSnap(m, c, v) { const s = LS.snaps(); (s[m] = s[m] || {})[c] = Math.round(v * 100) / 100; localStorage.setItem("mp_snapshots", JSON.stringify(s)); },
+  contrib() { try { return JSON.parse(localStorage.getItem("mp_contrib") || "{}"); } catch (e) { return {}; } },
+  saveContrib(o) { try { localStorage.setItem("mp_contrib", JSON.stringify(o)); } catch (e) {} },
+};
+window.LS = LS;
+
 function setContrib(label, value, month) {
   CONTRIB[label] = value;
+  LS.saveContrib(CONTRIB);
   renderSummary();
-  // Persistir snapshot mensual (para el histórico de gráficos).
+  // Snapshot mensual: en el servidor (si persiste) y en local (siempre).
   const m = month || thisMonth();
+  LS.saveSnap(m, label, value);
   fetch("/api/snapshot", {
     method: "POST", headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ month: m, category: label, value }),
-  }).then(() => { if (window.Charts) window.Charts.refresh(); }).catch(() => {});
+  }).finally(() => { if (window.Charts) window.Charts.refresh(); });
   if (window.Charts) window.Charts.refreshPie(CONTRIB);
 }
 
@@ -245,3 +257,14 @@ fetch("/api/config").then((r) => r.json()).then((c) => {
   if (c.steamid && !c.steamid.startsWith("TU_")) $("#steamid").value = c.steamid;
   if (c.moxfield) $("#moxfield").value = c.moxfield;
 }).catch(() => {});
+
+// ---- restaurar último estado (persistencia local) ----------------------
+(function restore() {
+  const saved = LS.contrib();
+  if (Object.keys(saved).length) {
+    Object.assign(CONTRIB, saved);
+    renderSummary();
+    const hint = document.getElementById("summaryHint");
+    if (hint) hint.textContent = "Mostrando tu último estado guardado. Vuelve a subir un documento para actualizar.";
+  }
+})();

--- a/app/static/charts.js
+++ b/app/static/charts.js
@@ -56,7 +56,10 @@
   // ---- Histórico mensual (snapshots del servidor) ----
   async function refresh() {
     let snaps = {};
-    try { snaps = await (await fetch("/api/snapshots")).json(); } catch (e) { return; }
+    try { snaps = await (await fetch("/api/snapshots")).json(); } catch (e) { snaps = {}; }
+    // Mezclar con la persistencia local (sobrevive a reinicios del hosting free).
+    const local = (window.LS && window.LS.snaps()) || {};
+    for (const m in local) snaps[m] = Object.assign({}, snaps[m], local[m]);
     const months = Object.keys(snaps).sort();
     const monthlyEmpty = document.getElementById("monthlyEmpty");
     if (!months.length) { if (monthlyEmpty) monthlyEmpty.style.display = "block"; return; }
@@ -120,6 +123,7 @@
   // Refresca al abrir la pestaña de gráficos.
   document.querySelectorAll('#tabs button[data-tab="graficos"]').forEach((b) =>
     b.addEventListener("click", () => { refresh(); refreshPie(window.CONTRIB || {}); }));
-  // Primera carga.
+  // Primera carga (incluye el estado restaurado desde localStorage).
   refresh();
+  refreshPie(window.CONTRIB || {});
 })();

--- a/app/static/favicon.svg
+++ b/app/static/favicon.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#8a6bff"/>
+      <stop offset="0.55" stop-color="#5ce1c4"/>
+      <stop offset="1" stop-color="#45c0ff"/>
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="14" fill="#0a0c18"/>
+  <rect x="13" y="34" width="9" height="17" rx="2.5" fill="url(#g)"/>
+  <rect x="27.5" y="24" width="9" height="27" rx="2.5" fill="url(#g)"/>
+  <rect x="42" y="15" width="9" height="36" rx="2.5" fill="url(#g)"/>
+</svg>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -4,6 +4,12 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Mi patrimonio · panel</title>
+  <meta name="description" content="Panel personal que consolida banco, Trade Republic, Nexo, skins de CS:GO y cartas Magic, con gráficos y valoración en vivo.">
+  <meta name="theme-color" content="#0a0c18">
+  <meta property="og:title" content="Mi patrimonio">
+  <meta property="og:description" content="Todo tu patrimonio en una vista: banco, acciones, cripto, skins y cartas Magic.">
+  <meta property="og:type" content="website">
+  <link rel="icon" type="image/svg+xml" href="{{ url_for('static', filename='favicon.svg') }}">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=Sora:wght@600;700;800&display=swap" rel="stylesheet">


### PR DESCRIPTION
Mejoras sobre la app ya desplegada (https://mi-patrimonio.onrender.com):

- **Persistencia local (localStorage):** el estado consolidado y el histórico mensual sobreviven a los reinicios del plan gratuito de Render (sin disco). Los gráficos mezclan datos del servidor + locales. Probado recargando con los datos del servidor vaciados → el panel se restaura solo.
- **Favicon + meta/OpenGraph** y servicio de `/favicon.ico` (quita el 404, mejor aspecto al compartir el enlace).
- **`/health`** para chequeos de estado.
- **Webhook de WhatsApp endurecido:** token opcional `WHATSAPP_WEBHOOK_TOKEN` para el endpoint público.

Sin cambios que rompan nada existente. Al fusionar, Render redepliega solo (`autoDeploy`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013GLk7agL8h761C1CYpmCGu

---
_Generated by [Claude Code](https://claude.ai/code/session_013GLk7agL8h761C1CYpmCGu)_