### PR TITLE
DB externa gratis (Supabase/Neon) + WhatsApp semanal domingos 19h

### DIFF
--- a/.github/workflows/weekly-whatsapp.yml
+++ b/.github/workflows/weekly-whatsapp.yml
@@ -4,7 +4,7 @@ name: WhatsApp semanal (subidas >10%)
 # subieron más del 10% algún día de la semana. Lee el histórico del repo.
 on:
   schedule:
-    - cron: "7 7 * * 1"      # lunes 07:07 UTC ≈ 09:07 Europe/Madrid
+    - cron: "7 17 * * 0"     # domingo 17:07 UTC ≈ 19:07 Europe/Madrid (verano; 18:07 en invierno)
   workflow_dispatch:
 
 jobs:

--- a/app/FREE_SETUP.md
+++ b/app/FREE_SETUP.md
@@ -51,8 +51,24 @@ guarda en el propio repositorio. La web (gráficos + subir PDFs) es opcional en
 
 En Render: **New → Blueprint** apuntando al repo (`render.yaml` en la raíz, plan *free*).
 Te da una URL pública para ver los gráficos y subir PDFs. Se duerme cuando no la
-usas y despierta al abrirla. *(El histórico de precios no depende de la web: vive
-en el repo gracias a Actions.)*
+usas y despierta al abrirla.
+
+### Base de datos gratis (Supabase) — datos compartidos en móvil/PC/amigos
+
+La app guarda el patrimonio en PostgreSQL si defines `DATABASE_URL` (si no, usa
+SQLite efímero). Con una base gratuita externa los datos persisten y son los
+mismos en cualquier dispositivo:
+
+1. Crea un proyecto gratis en **https://supabase.com** (o **https://neon.tech**).
+2. En Supabase → *Project Settings → Database → Connection string* → copia la
+   **URI del Pooler** (la de `...pooler.supabase.com`, compatible con IPv4;
+   la conexión directa NO funciona desde Render). Formato:
+   `postgresql://postgres.<ref>:<password>@aws-0-<region>.pooler.supabase.com:5432/postgres`
+3. En Render → servicio **mi-patrimonio** → *Environment* → añade
+   `DATABASE_URL` = esa URI → **Save** (redeploya). La app crea las tablas sola.
+
+> El SSL se activa automáticamente. Si la conexión fallara, prueba la cadena del
+> *Session pooler* (puerto 5432) en lugar del *Transaction pooler* (6543).
 
 ## ¿Recibir PDFs por WhatsApp?
 

--- a/app/jobs/scheduler.py
+++ b/app/jobs/scheduler.py
@@ -31,11 +31,11 @@ def start_scheduler():
     sched = BackgroundScheduler(timezone=_TZ)
     sched.add_job(track_prices.main, CronTrigger(hour=8, minute=7),
                   id="track_prices", replace_existing=True, misfire_grace_time=3600)
-    sched.add_job(weekly_whatsapp.main, CronTrigger(day_of_week="mon", hour=9, minute=7),
+    sched.add_job(weekly_whatsapp.main, CronTrigger(day_of_week="sun", hour=19, minute=7),
                   id="weekly_whatsapp", replace_existing=True, misfire_grace_time=3600)
     sched.add_job(monthly_reminder.main, CronTrigger(day=1, hour=10, minute=7),
                   id="monthly_reminder", replace_existing=True, misfire_grace_time=86400)
     sched.start()
     _started = True
-    print(f"Scheduler activo ({_TZ}): precios 08:07, WhatsApp semanal lun 09:07, "
+    print(f"Scheduler activo ({_TZ}): precios 08:07, WhatsApp semanal dom 19:07, "
           "recordatorio mensual día 1 10:07.")

--- a/app/sources/db.py
+++ b/app/sources/db.py
@@ -26,6 +26,9 @@ def _engine_url():
             url = url.replace("postgres://", "postgresql+psycopg2://", 1)
         elif url.startswith("postgresql://"):
             url = url.replace("postgresql://", "postgresql+psycopg2://", 1)
+        # Supabase/Neon exigen SSL; lo activamos si no se indicó.
+        if "sslmode=" not in url:
+            url += ("&" if "?" in url else "?") + "sslmode=require"
         return url, False
     os.makedirs(_DATA_DIR, exist_ok=True)
     return "sqlite:///" + os.path.join(_DATA_DIR, "patrimonio.db"), True
@@ -50,7 +53,17 @@ valuation_cache = Table(
     Column("day", String(10)),
     Column("payload", Text),
 )
-_meta.create_all(_engine)
+
+_ready = False
+
+
+def _ensure():
+    """Crea las tablas la primera vez (no en el import, para no romper el arranque
+    si la base de datos tarda un momento en estar disponible)."""
+    global _ready
+    if not _ready:
+        _meta.create_all(_engine)
+        _ready = True
 
 
 def backend():
@@ -59,6 +72,7 @@ def backend():
 
 # ---- snapshots -----------------------------------------------------------
 def set_snapshot(month, category, value):
+    _ensure()
     now = datetime.datetime.utcnow().isoformat(timespec="seconds")
     value = round(float(value), 2)
     with _engine.begin() as conn:
@@ -72,6 +86,7 @@ def set_snapshot(month, category, value):
 
 
 def get_snapshots():
+    _ensure()
     out = {}
     with _engine.connect() as conn:
         for row in conn.execute(select(snapshots.c.month, snapshots.c.category, snapshots.c.value)):
@@ -80,12 +95,14 @@ def get_snapshots():
 
 
 def reset_snapshots():
+    _ensure()
     with _engine.begin() as conn:
         conn.execute(delete(snapshots))
 
 
 # ---- caché diaria de valoraciones ---------------------------------------
 def cache_get_today(key):
+    _ensure()
     today = datetime.date.today().isoformat()
     with _engine.connect() as conn:
         row = conn.execute(select(valuation_cache.c.day, valuation_cache.c.payload)
@@ -99,6 +116,7 @@ def cache_get_today(key):
 
 
 def cache_put(key, payload):
+    _ensure()
     today = datetime.date.today().isoformat()
     blob = json.dumps(payload, ensure_ascii=False)
     with _engine.begin() as conn:

--- a/render.yaml
+++ b/render.yaml
@@ -1,11 +1,8 @@
-# Blueprint de Render: panel web (plan gratuito) + PostgreSQL gratuito.
-# Los datos (snapshots + caché diaria) viven en la base de datos, así son los
-# mismos en móvil, PC y al compartir el enlace. Los mensajes programados
-# (precios, WhatsApp) corren gratis en GitHub Actions (ver app/FREE_SETUP.md).
-databases:
-  - name: patrimonio-db
-    plan: free                # PostgreSQL gratuito gestionado por Render
-
+# Blueprint de Render: panel web (plan gratuito).
+# La base de datos es EXTERNA y gratuita (Supabase o Neon): pega su cadena de
+# conexión en la variable DATABASE_URL desde el panel de Render. Así los datos
+# persisten y se comparten entre móvil/PC/amigos, sin recursos que bloqueen el
+# deploy. Los mensajes programados (precios, WhatsApp) corren en GitHub Actions.
 services:
   - type: web
     name: mi-patrimonio
@@ -16,10 +13,10 @@ services:
     autoDeploy: true
     healthCheckPath: /health
     envVars:
+      # Pega aquí (en Render → Environment) la cadena de conexión de Supabase/Neon.
+      # Usa la del POOLER (IPv4). Si no la defines, la app usa SQLite efímero.
       - key: DATABASE_URL
-        fromDatabase:
-          name: patrimonio-db
-          property: connectionString
+        sync: false
       - key: ENABLE_SCHEDULER
         value: "0"            # los jobs van por GitHub Actions, no en la web
       # Opcionales: solo si además quieres RECIBIR PDFs por WhatsApp (vía Twilio).


### PR DESCRIPTION
- **Base de datos externa gratuita** (Supabase o Neon) vía `DATABASE_URL`. Se quita el Postgres gestionado por el blueprint (que estaba **bloqueando el redeploy** de Render). La app activa SSL sola y cae a SQLite si no hay `DATABASE_URL`.
- **Arranque robusto:** las tablas se crean de forma perezosa (no en el import), así un hipo de la DB no tumba el arranque.
- **Aviso semanal de WhatsApp → domingos 19:07** (Europe/Madrid), en el cron de GitHub Actions y en el scheduler.
- Guía de Supabase en `app/FREE_SETUP.md`.

Probado: importa sin conectar, seed local OK, y no crashea con `DATABASE_URL` inválida.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013GLk7agL8h761C1CYpmCGu

---
_Generated by [Claude Code](https://claude.ai/code/session_013GLk7agL8h761C1CYpmCGu)_