### PR TITLE
Cripto en vivo (CoinGecko) + toques de color + gestor de cartas claro

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -24,7 +24,7 @@ import tempfile
 
 from flask import Flask, jsonify, render_template, request
 
-from sources import bank, trade_republic, nexo, steam, moxfield, db, ingest
+from sources import bank, trade_republic, nexo, steam, moxfield, db, ingest, crypto
 
 app = Flask(__name__)
 app.config["MAX_CONTENT_LENGTH"] = 32 * 1024 * 1024
@@ -209,6 +209,8 @@ def api_magic():
     if not reference and not decklist.strip():
         return jsonify({"error": "Indica una URL/ID de Moxfield o pega una decklist."}), 400
     nocache = bool(body.get("refresh"))
+    # Guarda la lista de cartas para reutilizarla (carga al volver, watchlist).
+    db.set_setting("magic_cards", {"reference": reference, "decklist": decklist})
     try:
         key = "magic:" + hashlib.sha1((reference + "|" + decklist).encode()).hexdigest()
         if nocache:
@@ -216,6 +218,45 @@ def api_magic():
             db.cache_put(key, data)
         else:
             data = _cached_daily(key, lambda: moxfield.analyze(reference=reference, decklist=decklist))
+        return jsonify(data)
+    except Exception as exc:  # noqa: BLE001
+        return jsonify({"error": str(exc)}), 502
+
+
+@app.route("/api/cards", methods=["GET", "POST"])
+def api_cards():
+    """Lista de cartas guardada (para precargar/guardar el gestor de cartas)."""
+    if request.method == "POST":
+        body = request.get_json(silent=True) or {}
+        db.set_setting("magic_cards", {"reference": (body.get("reference") or "").strip(),
+                                       "decklist": body.get("decklist") or ""})
+        return jsonify({"ok": True})
+    return jsonify(db.get_setting("magic_cards", {"reference": "", "decklist": ""}))
+
+
+@app.route("/api/crypto", methods=["GET", "POST"])
+def api_crypto():
+    """Valora tus cripto en vivo (CoinGecko). GET usa lo guardado; POST guarda."""
+    if request.method == "POST":
+        body = request.get_json(silent=True) or {}
+        holdings_text = body.get("holdings", "")
+        db.set_setting("crypto_holdings", holdings_text)
+        nocache = bool(body.get("refresh"))
+    else:
+        holdings_text = db.get_setting("crypto_holdings", "") or ""
+        nocache = False
+    holdings = crypto.parse_holdings(holdings_text)
+    if not holdings:
+        return jsonify({"source": "Cripto", "category": "Cripto", "positions": [],
+                        "total": 0.0, "currency": "EUR", "warnings": [], "holdings_text": holdings_text})
+    key = "crypto:" + hashlib.sha1(holdings_text.encode()).hexdigest()
+    try:
+        if nocache:
+            data = crypto.analyze(holdings)
+            db.cache_put(key, data)
+        else:
+            data = _cached_daily(key, lambda: crypto.analyze(holdings))
+        data["holdings_text"] = holdings_text
         return jsonify(data)
     except Exception as exc:  # noqa: BLE001
         return jsonify({"error": str(exc)}), 502

--- a/app/sources/crypto.py
+++ b/app/sources/crypto.py
@@ -1,0 +1,77 @@
+"""
+Cripto: valoración EN VIVO de tus holdings con CoinGecko (gratis, sin API key).
+
+Introduces tus tenencias (cantidad + moneda) y se valoran al precio actual.
+Ej.:  "0.5 BTC", "2 ETH", "100 ADA"  →  valor en € de cada una y total.
+"""
+
+from . import http
+from .common import Position
+
+SOURCE = "Cripto"
+CATEGORY = "Cripto"
+
+# Símbolo -> id de CoinGecko (las más comunes). Si no está, se usa lo escrito
+# como id directamente (puedes poner el id de CoinGecko: 'bitcoin', 'nexo'…).
+COIN_IDS = {
+    "btc": "bitcoin", "eth": "ethereum", "sol": "solana", "usdt": "tether",
+    "usdc": "usd-coin", "bnb": "binancecoin", "xrp": "ripple", "ada": "cardano",
+    "doge": "dogecoin", "dot": "polkadot", "matic": "matic-network", "ltc": "litecoin",
+    "link": "chainlink", "avax": "avalanche-2", "atom": "cosmos", "near": "near",
+    "trx": "tron", "shib": "shiba-inu", "uni": "uniswap", "xlm": "stellar",
+    "algo": "algorand", "vet": "vechain", "ftm": "fantom", "sand": "the-sandbox",
+    "mana": "decentraland", "aave": "aave", "grt": "the-graph", "xmr": "monero",
+    "bch": "bitcoin-cash", "etc": "ethereum-classic", "fil": "filecoin",
+    "icp": "internet-computer", "ape": "apecoin", "arb": "arbitrum", "op": "optimism",
+    "inj": "injective-protocol", "sui": "sui", "sei": "sei-network", "pepe": "pepe",
+    "nexo": "nexo", "ton": "the-open-network", "cro": "crypto-com-chain",
+}
+
+
+def parse_holdings(text):
+    """Convierte texto libre en una lista de {amount, coin}. Acepta '0.5 BTC',
+    'BTC 0.5', con coma o punto decimal, una por línea."""
+    out = []
+    for line in (text or "").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        amount, coin = None, None
+        for tok in line.replace(",", ".").split():
+            try:
+                amount = float(tok)
+            except ValueError:
+                coin = tok
+        if amount is not None and coin:
+            out.append({"amount": amount, "coin": coin.lower()})
+    return out
+
+
+def _prices(ids, vs="eur"):
+    if not ids:
+        return {}
+    url = ("https://api.coingecko.com/api/v3/simple/price?ids="
+           + ",".join(sorted(ids)) + "&vs_currencies=" + vs)
+    status, data = http.get_json(url)
+    return data if status == 200 and data else {}
+
+
+def analyze(holdings, currency="eur"):
+    cur = currency.lower()
+    resolved = [(h, COIN_IDS.get(h["coin"], h["coin"])) for h in holdings]
+    prices = _prices({cid for _, cid in resolved}, cur)
+    positions, warnings = [], []
+    for h, cid in resolved:
+        unit = prices.get(cid, {}).get(cur)
+        if unit is None:
+            warnings.append(f"Sin precio para «{h['coin'].upper()}» (id CoinGecko '{cid}').")
+            unit = 0.0
+        positions.append(Position(
+            source=SOURCE, category=CATEGORY, name=h["coin"].upper(),
+            quantity=h["amount"], unit_value=unit, value=round(unit * h["amount"], 2),
+            currency=currency.upper(), extra={"tag": cid},
+        ).finalize())
+    total = round(sum(p.value for p in positions), 2)
+    return {"source": SOURCE, "category": CATEGORY,
+            "positions": [p.to_dict() for p in positions],
+            "total": total, "currency": currency.upper(), "warnings": warnings}

--- a/app/sources/db.py
+++ b/app/sources/db.py
@@ -53,6 +53,11 @@ valuation_cache = Table(
     Column("day", String(10)),
     Column("payload", Text),
 )
+settings = Table(
+    "settings", _meta,
+    Column("skey", String(120), primary_key=True),
+    Column("svalue", Text),
+)
 
 _ready = False
 
@@ -126,3 +131,25 @@ def cache_put(key, payload):
         if res.rowcount == 0:
             conn.execute(insert(valuation_cache).values(
                 cache_key=key, day=today, payload=blob))
+
+
+# ---- ajustes (holdings cripto, lista de cartas…) -------------------------
+def get_setting(key, default=None):
+    _ensure()
+    with _engine.connect() as conn:
+        row = conn.execute(select(settings.c.svalue).where(settings.c.skey == key)).first()
+    if not row:
+        return default
+    try:
+        return json.loads(row.svalue)
+    except (ValueError, TypeError):
+        return default
+
+
+def set_setting(key, value):
+    _ensure()
+    blob = json.dumps(value, ensure_ascii=False)
+    with _engine.begin() as conn:
+        res = conn.execute(update(settings).where(settings.c.skey == key).values(svalue=blob))
+        if res.rowcount == 0:
+            conn.execute(insert(settings).values(skey=key, svalue=blob))

--- a/app/static/app.js
+++ b/app/static/app.js
@@ -146,16 +146,98 @@ $("#steamForm").addEventListener("submit", async (ev) => {
   finally { btn.disabled = false; }
 });
 
-// ---- Magic (Moxfield + Scryfall) ---------------------------------------
-$("#magicForm").addEventListener("submit", async (ev) => {
+// ---- Cripto (CoinGecko en vivo) ----------------------------------------
+$("#cryptoForm").addEventListener("submit", async (ev) => {
   ev.preventDefault();
-  const target = $("#magicResult");
+  const target = $("#cryptoResult");
   const btn = $("button", ev.target); btn.disabled = true;
-  setStatus(target, "Obteniendo cartas y pidiendo precios en vivo a Scryfall…");
+  setStatus(target, "Pidiendo precios en vivo a CoinGecko…");
+  try {
+    const res = await fetch("/api/crypto", {
+      method: "POST", headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ holdings: $("#cryptoHoldings").value, refresh: true }),
+    });
+    const json = await res.json();
+    if (!res.ok) throw new Error(json.error || "Error");
+    setStatus(target, "");
+    renderPositions(json, target);
+  } catch (e) { setStatus(target, e.message, true); }
+  finally { btn.disabled = false; }
+});
+// Cargar holdings guardados al iniciar.
+fetch("/api/crypto").then((r) => r.json()).then((j) => {
+  if (j.holdings_text) $("#cryptoHoldings").value = j.holdings_text;
+  if (j.positions && j.positions.length) renderPositions(j, $("#cryptoResult"));
+}).catch(() => {});
+
+// ---- Magic: gestor de cartas claro -------------------------------------
+let CARDS = [];   // {qty, name, set, cn, foil}
+
+function cardToLine(c) {
+  let s = `${c.qty} ${c.name}`;
+  if (c.set) s += ` (${c.set})${c.cn ? " " + c.cn : ""}`;
+  if (c.foil) s += " *F*";
+  return s;
+}
+function cardsToDecklist() { return CARDS.map(cardToLine).join("\n"); }
+
+function parseDecklistJS(text) {
+  const out = [];
+  for (let raw of (text || "").split("\n")) {
+    let line = raw.trim();
+    if (!line || /^(\/\/|#|Deck|Commander|Sideboard|About|Maybeboard)/.test(line)) continue;
+    if (line.startsWith("SB:")) line = line.slice(3).trim();
+    const m = line.match(/^(?:(\d+)\s*x?\s+)?(.+?)(?:\s+\(([A-Za-z0-9]{2,6})\)\s+(\S+))?((?:\s+[*#][^*#\s]+[*#]?)*)\s*$/);
+    if (!m) continue;
+    const flags = (m[5] || "").toLowerCase();
+    out.push({ qty: m[1] ? parseInt(m[1]) : 1, name: m[2].trim(), set: m[3] || "", cn: m[4] || "",
+               foil: flags.includes("*f*") || flags.includes("*e*") });
+  }
+  return out;
+}
+
+function renderCards() {
+  const el = $("#cardList");
+  if (!CARDS.length) { el.innerHTML = `<p class="hint">Aún no hay cartas. Añade una arriba o importa una decklist.</p>`; return; }
+  el.innerHTML = CARDS.map((c, i) => `<div class="card-row">
+    <span class="card-q">${c.qty}×</span>
+    <span class="card-n">${c.name}${c.set ? ` <span class="tag">${c.set.toUpperCase()}${c.cn ? " " + c.cn : ""}</span>` : ""}${c.foil ? ` <span class="tag tag-foil">foil</span>` : ""}</span>
+    <button type="button" class="card-del" data-i="${i}" aria-label="Quitar">×</button>
+  </div>`).join("");
+  $$(".card-del", el).forEach((b) => b.addEventListener("click", () => { CARDS.splice(+b.dataset.i, 1); renderCards(); saveCards(); }));
+}
+
+function saveCards() {
+  fetch("/api/cards", { method: "POST", headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ reference: $("#moxfield").value.trim(), decklist: cardsToDecklist() }) }).catch(() => {});
+}
+
+$("#cardAddForm").addEventListener("submit", (ev) => {
+  ev.preventDefault();
+  const name = $("#cardName").value.trim();
+  if (!name) return;
+  CARDS.push({ qty: Math.max(1, parseInt($("#cardQty").value) || 1), name,
+               set: $("#cardSet").value.trim(), cn: $("#cardCn").value.trim(), foil: $("#cardFoil").checked });
+  $("#cardName").value = ""; $("#cardSet").value = ""; $("#cardCn").value = ""; $("#cardFoil").checked = false; $("#cardQty").value = 1;
+  $("#cardName").focus();
+  renderCards(); saveCards();
+});
+
+$("#importBtn").addEventListener("click", () => {
+  const parsed = parseDecklistJS($("#decklist").value);
+  if (parsed.length) { CARDS = CARDS.concat(parsed); $("#decklist").value = ""; renderCards(); saveCards(); }
+});
+
+$("#valuarBtn").addEventListener("click", async () => {
+  const target = $("#magicResult");
+  const ref = $("#moxfield").value.trim();
+  if (!CARDS.length && !ref) { setStatus(target, "Añade cartas o pon un mazo de Moxfield.", true); return; }
+  const btn = $("#valuarBtn"); btn.disabled = true;
+  setStatus(target, "Pidiendo precios en vivo a Scryfall…");
   try {
     const res = await fetch("/api/magic", {
       method: "POST", headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ moxfield: $("#moxfield").value.trim(), decklist: $("#decklist").value }),
+      body: JSON.stringify({ moxfield: ref, decklist: cardsToDecklist() }),
     });
     const json = await res.json();
     if (!res.ok) throw new Error(json.error || "Error");
@@ -164,6 +246,13 @@ $("#magicForm").addEventListener("submit", async (ev) => {
   } catch (e) { setStatus(target, e.message, true); }
   finally { btn.disabled = false; }
 });
+
+// Cargar lista de cartas guardada.
+fetch("/api/cards").then((r) => r.json()).then((j) => {
+  if (j.reference) $("#moxfield").value = j.reference;
+  if (j.decklist) { CARDS = parseDecklistJS(j.decklist); }
+  renderCards();
+}).catch(() => renderCards());
 
 // ===== BANCO: desglose de gastos netos + enlace de bizums ===============
 let BANK = null, LINKS = {};

--- a/app/static/charts.js
+++ b/app/static/charts.js
@@ -5,7 +5,8 @@
   "use strict";
   if (typeof Chart === "undefined") return;
 
-  const PALETTE = ["#ffffff", "#c7c7cc", "#8e8e93", "#d1d1d6", "#636366", "#aeaeb2", "#48484a", "#e6e6ea"];
+  // Blanco y negro con toques de color en los detalles.
+  const PALETTE = ["#f5f5f7", "#6ea8ff", "#46d39a", "#c7c7cc", "#ff6b9d", "#8e8e93", "#ffce6b", "#b388ff"];
   const GRID = "rgba(255,255,255,.10)";
   const TICK = "#8e8e93";
   const eur = (n) => "€" + Number(n).toLocaleString("es-ES", { maximumFractionDigits: 0 });

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -9,11 +9,14 @@
   --line: rgba(255, 255, 255, .12);
   --glass: rgba(255, 255, 255, .055);
   --grad: linear-gradient(180deg, #ffffff 0%, #b9b9bf 100%);
-  --pos: #ffffff;          /* ganancias / positivo */
-  --neg: #8a8a8f;          /* gastos / negativo (en escala de grises) */
-  --amber: #d8d8dc;
-  --green: #ffffff;
-  --red: #8a8a8f;
+  /* base en blanco y negro + toques de color en los detalles */
+  --accent: #6ea8ff;       /* acento (focos, detalles) */
+  --pos: #46d39a;          /* ganancias / positivo (verde) */
+  --neg: #ff6b6b;          /* gastos / negativo (rojo) */
+  --amber: #ffce6b;
+  --green: #46d39a;
+  --red: #ff6b6b;
+  --foil: linear-gradient(110deg, #8a6bff, #46d3c4, #ff6b9d);
   --radius: 22px;
   --shadow: 0 18px 50px -16px rgba(0, 0, 0, .8);
   font-synthesis: none;
@@ -55,9 +58,12 @@ main { max-width: 1060px; margin: 0 auto; padding: 0 20px 90px; }
 
 /* ---------- Hero ---------- */
 .hero { position: relative; max-width: 1060px; margin: 0 auto; padding: 120px 20px 60px; text-align: center; }
-.badge { display: inline-flex; align-items: center; gap: 8px; font-size: 12.5px; font-weight: 600;
-  letter-spacing: .02em; color: var(--ink); padding: 7px 14px; border-radius: 999px;
+.badge { display: inline-flex; align-items: center; gap: 9px; font-size: 12.5px; font-weight: 600;
+  letter-spacing: .02em; color: var(--ink); padding: 7px 14px 7px 12px; border-radius: 999px;
   border: 1px solid var(--line); background: rgba(255, 255, 255, .06); backdrop-filter: blur(10px); }
+.badge .dot { width: 8px; height: 8px; border-radius: 50%; background: var(--pos);
+  box-shadow: 0 0 0 3px rgba(70, 211, 154, .25); animation: pulse 2s infinite; }
+@keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: .45; } }
 .hero-title { font-family: "Sora", "Inter", sans-serif; font-weight: 800;
   font-size: clamp(44px, 8vw, 86px); line-height: 1.02; letter-spacing: -.03em; margin: 20px 0 14px; }
 .grad { background: var(--grad); -webkit-background-clip: text; background-clip: text;
@@ -129,8 +135,10 @@ input[type=text], textarea { width: 100%; background: rgba(255, 255, 255, .05); 
   border: 1px solid var(--line); border-radius: 14px; padding: 13px 15px; font-size: 14px; transition: .2s;
   backdrop-filter: blur(8px); }
 input[type=text] { flex: 1; min-width: 240px; }
-input[type=text]:focus, textarea:focus { outline: none; border-color: rgba(255, 255, 255, .55);
-  box-shadow: 0 0 0 4px rgba(255, 255, 255, .1); }
+input[type=text]:focus, input[type=number]:focus, textarea:focus { outline: none;
+  border-color: var(--accent); box-shadow: 0 0 0 4px rgba(110, 168, 255, .18); }
+input[type=number] { background: rgba(255, 255, 255, .05); color: var(--ink);
+  border: 1px solid var(--line); border-radius: 12px; padding: 12px; font-size: 14px; width: 72px; text-align: center; }
 textarea { margin-top: 12px; font-family: ui-monospace, monospace; font-size: 13px; line-height: 1.6; resize: vertical; }
 
 button[type=submit] { position: relative; border: 1px solid rgba(255, 255, 255, .2); cursor: pointer;
@@ -176,6 +184,23 @@ select:focus { outline: none; border-color: rgba(255, 255, 255, .5); }
 .bar > span { display: block; height: 100%; background: linear-gradient(90deg, #fff, #b9b9bf); border-radius: 6px; }
 .thumb { width: 30px; height: 30px; vertical-align: middle; border-radius: 6px; margin-right: 10px;
   border: 1px solid var(--line); background: rgba(255, 255, 255, .06); }
+
+/* ---------- Gestor de cartas (Magic) ---------- */
+.card-add { display: flex; gap: 10px; flex-wrap: wrap; align-items: center; }
+.card-add input[type=text] { flex: 1; min-width: 160px; }
+.card-add input.small { flex: 0 0 90px; min-width: 0; }
+.foil-check { display: inline-flex; align-items: center; gap: 6px; color: var(--muted); font-size: 13px; white-space: nowrap; }
+.bulk { margin: 14px 0 4px; border: 1px solid var(--line); border-radius: 14px; padding: 4px 14px; background: rgba(255, 255, 255, .02); }
+.bulk summary { cursor: pointer; color: var(--muted); font-size: 13px; padding: 10px 0; }
+.card-list { display: flex; flex-direction: column; gap: 8px; margin-top: 8px; }
+.card-row { display: flex; align-items: center; gap: 10px; padding: 10px 14px; border-radius: 12px;
+  border: 1px solid var(--line); background: rgba(255, 255, 255, .04); }
+.card-q { font-family: "Sora", sans-serif; font-weight: 700; color: var(--accent); min-width: 30px; }
+.card-n { flex: 1; }
+.card-del { background: rgba(255, 107, 107, .12); color: var(--neg); border: 1px solid rgba(255, 107, 107, .3);
+  width: 28px; height: 28px; border-radius: 8px; cursor: pointer; font-size: 16px; line-height: 1; padding: 0; }
+.card-del:hover { background: rgba(255, 107, 107, .22); }
+.tag-foil { color: #0a0a0c; background: var(--foil); border: 0; font-weight: 700; }
 
 .status { font-size: 13px; color: var(--muted); margin: 12px 0 0; }
 .status.err { color: #d0d0d4; }

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -28,7 +28,7 @@
   <!-- HERO -->
   <header class="hero">
     <div class="hero-inner">
-      <span class="badge reveal">● Patrimonio en tiempo real</span>
+      <span class="badge reveal"><span class="dot"></span> Patrimonio en tiempo real</span>
       <h1 class="hero-title reveal">Mi <span class="grad">patrimonio</span></h1>
       <p class="hero-sub reveal">Banco, Trade Republic, Nexo, skins de CS:GO y cartas Magic
          — todo consolidado en una sola vista, con valoración en vivo.</p>
@@ -63,6 +63,7 @@
       <button data-tab="banco"><span>🏦</span> Banco / Gastos</button>
       <button data-tab="tr"><span>📈</span> Trade Republic</button>
       <button data-tab="nexo"><span>🪙</span> Nexo</button>
+      <button data-tab="cripto"><span>₿</span> Cripto</button>
       <button data-tab="csgo"><span>🔫</span> CS:GO Skins</button>
       <button data-tab="magic"><span>🃏</span> Cartas Magic</button>
     </nav>
@@ -135,6 +136,23 @@
       <div id="nexoResult"></div>
     </section>
 
+    <!-- CRIPTO -->
+    <section class="panel glass tabpane" id="pane-cripto">
+      <div class="panel-head">
+        <div class="icon-chip">₿</div>
+        <div><h2>Cripto · valoración en vivo (CoinGecko)</h2>
+          <p class="sub2">Escribe tus tenencias (una por línea): <code>cantidad MONEDA</code>. Precio en tiempo real.</p></div>
+      </div>
+      <form id="cryptoForm">
+        <textarea id="cryptoHoldings" rows="5"
+          placeholder="0.5 BTC&#10;2 ETH&#10;150 ADA&#10;500 NEXO"></textarea>
+        <div class="row" style="margin-top:10px">
+          <button type="submit">Valorar cripto</button>
+        </div>
+      </form>
+      <div id="cryptoResult"></div>
+    </section>
+
     <!-- CS:GO -->
     <section class="panel glass tabpane" id="pane-csgo">
       <div class="panel-head">
@@ -153,17 +171,35 @@
     <section class="panel glass tabpane" id="pane-magic">
       <div class="panel-head">
         <div class="icon-chip">🃏</div>
-        <div><h2>Magic · mazos de Moxfield</h2>
-          <p class="sub2">Precio en tiempo real con Scryfall. Pega la URL del mazo o la decklist.</p></div>
+        <div><h2>Magic · tus cartas (precio en vivo con Scryfall)</h2>
+          <p class="sub2">Añade cartas una a una, o importa una decklist / mazo de Moxfield. Se guardan para la próxima vez.</p></div>
       </div>
-      <form id="magicForm">
-        <div class="row">
-          <input type="text" id="moxfield" placeholder="URL o ID de mazo de Moxfield (opcional)" />
-          <button type="submit">Valorar</button>
-        </div>
-        <textarea id="decklist" rows="6"
-          placeholder="…o pega aquí la decklist:&#10;1 Sol Ring&#10;1 Lightning Bolt&#10;1 Counterspell"></textarea>
+
+      <!-- Añadir una carta de forma clara -->
+      <form id="cardAddForm" class="card-add">
+        <input type="number" id="cardQty" min="1" value="1" step="1" aria-label="Cantidad" />
+        <input type="text" id="cardName" placeholder="Nombre de la carta (p. ej. Sol Ring)" />
+        <input type="text" id="cardSet" placeholder="Set (op.)" class="small" />
+        <input type="text" id="cardCn" placeholder="Nº (op.)" class="small" />
+        <label class="foil-check"><input type="checkbox" id="cardFoil" /> Foil</label>
+        <button type="submit">+ Añadir</button>
       </form>
+
+      <details class="bulk">
+        <summary>Importar en bloque (decklist o Moxfield)</summary>
+        <div class="row" style="margin-top:10px">
+          <input type="text" id="moxfield" placeholder="URL o ID de mazo de Moxfield (opcional)" />
+        </div>
+        <textarea id="decklist" rows="5"
+          placeholder="1 Sol Ring (CMR) 472 *F*&#10;1 Lightning Bolt&#10;2 Counterspell"></textarea>
+        <div class="row" style="margin-top:10px"><button type="button" id="importBtn">Importar a mi lista</button></div>
+      </details>
+
+      <h3>Mi lista de cartas</h3>
+      <div id="cardList" class="card-list"></div>
+      <div class="row" style="margin-top:12px">
+        <button type="button" id="valuarBtn">Valorar mi lista</button>
+      </div>
       <div id="magicResult"></div>
     </section>
 


### PR DESCRIPTION
- **Cripto:** nueva pestaña con valoración **en vivo (CoinGecko, gratis)**. Escribes tus tenencias (`0.5 BTC`, `2 ETH`…), se valoran al momento y suman al patrimonio. Se guardan en la DB. Probado: 0.5 BTC ≈ 26.452 €.
- **Toques de color** sobre la base blanco y negro: ganancias en verde, gastos en rojo, focos con acento, punto "en vivo" pulsante, etiqueta foil, y algo de color en los gráficos.
- **Gestor de cartas más claro:** añadir cartas una a una (cantidad · nombre · set · nº · foil), import en bloque plegable (decklist/Moxfield), lista persistida con botón de quitar, y botón de valorar. La lista se guarda en la DB.
- (Tu Steam ya es público → la pestaña CS:GO valora tus skins reales.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013GLk7agL8h761C1CYpmCGu

---
_Generated by [Claude Code](https://claude.ai/code/session_013GLk7agL8h761C1CYpmCGu)_