### PR TITLE
Endpoint /api/version para verificar el build desplegado

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -80,9 +80,19 @@ def index():
     return render_template("index.html")
 
 
+APP_VERSION = "2026-06-baseline-r10"   # se sube en cada cambio para verificar el deploy
+
+
 @app.route("/health")
 def health():
     return jsonify({"status": "ok"})
+
+
+@app.route("/api/version")
+def api_version():
+    """Para verificar qué build está realmente desplegado."""
+    return jsonify({"version": APP_VERSION, "db": db.backend(),
+                    "sources": ["banco", "trade_republic", "csgo", "magic"]})
 
 
 @app.route("/favicon.ico")


### PR DESCRIPTION
Añade `/api/version` para poder comprobar qué build está realmente en producción (la web estaba sirviendo un build antiguo). Devuelve versión, backend de DB y fuentes activas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013GLk7agL8h761C1CYpmCGu

---
_Generated by [Claude Code](https://claude.ai/code/session_013GLk7agL8h761C1CYpmCGu)_