### PR TITLE
Fix: SSL solo en hosts externos (conexión interna de Render)

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -80,7 +80,7 @@ def index():
     return render_template("index.html")
 
 
-APP_VERSION = "2026-06-baseline-r10"   # se sube en cada cambio para verificar el deploy
+APP_VERSION = "2026-06-baseline-r11"   # se sube en cada cambio para verificar el deploy
 
 
 @app.route("/health")

--- a/app/sources/db.py
+++ b/app/sources/db.py
@@ -26,8 +26,11 @@ def _engine_url():
             url = url.replace("postgres://", "postgresql+psycopg2://", 1)
         elif url.startswith("postgresql://"):
             url = url.replace("postgresql://", "postgresql+psycopg2://", 1)
-        # Supabase/Neon exigen SSL; lo activamos si no se indicó.
-        if "sslmode=" not in url:
+        # Solo forzar SSL en hosts EXTERNOS (con dominio, p. ej. Supabase/Neon o
+        # la conexión externa de Render). Las conexiones INTERNAS de Render
+        # (host sin punto) van por red privada y no usan SSL.
+        host = url.split("@")[-1].split("/")[0].split(":")[0] if "@" in url else ""
+        if "." in host and "sslmode=" not in url:
             url += ("&" if "?" in url else "?") + "sslmode=require"
         return url, False
     os.makedirs(_DATA_DIR, exist_ok=True)


### PR DESCRIPTION
La conexión interna de Render Postgres (red privada) no usa SSL; forzar `sslmode=require` la rompía (500). Ahora solo se fuerza SSL en hosts externos con dominio (Supabase/Neon/conexión externa).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013GLk7agL8h761C1CYpmCGu

---
_Generated by [Claude Code](https://claude.ai/code/session_013GLk7agL8h761C1CYpmCGu)_