### PR TITLE
Refactor arquitectónico + rediseño de la galería de cartas Magic

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,20 @@
+name: Tests
+
+on:
+  push:
+    branches: [master, "claude/**"]
+  pull_request:
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Instalar dependencias
+        run: pip install -r app/requirements-dev.txt
+      - name: Ejecutar tests
+        run: python -m pytest
+        working-directory: app

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+# Python
+__pycache__/
+*.py[cod]
+.pytest_cache/
+*.egg-info/
+
+# Datos locales (SQLite, inbox de PDFs)
+app/data/
+data/
+
+# Configuración local con credenciales
+app/config.json
+
+# Entornos
+.venv/
+venv/
+.env

--- a/app/app.py
+++ b/app/app.py
@@ -1,42 +1,62 @@
 """
-Panel de patrimonio personal: consolida banco, Trade Republic, Nexo,
-skins de CS:GO (Steam) y cartas Magic (Moxfield + precios Scryfall en vivo).
+Panel de patrimonio personal: consolida banco (PDF o Wealth Reader), Trade
+Republic, skins de CS:GO (Steam) y cartas Magic (Scryfall), con valoración en
+vivo, histórico mensual en base de datos y resumen por WhatsApp.
 
-Uso:
+Uso local:
     pip install -r requirements.txt
     python app.py            # http://127.0.0.1:5000
 
-Fuentes por informe (subes archivo cada mes):
-    POST /api/bank             (PDF del banco)        -> gastos netos
-    POST /api/trade-republic   (PDF/CSV)              -> acciones/ETFs
-    POST /api/nexo             (CSV/PDF)              -> cripto
-Fuentes en vivo (API):
-    GET  /api/steam?steamid=...&currency=eur          -> skins CS:GO
-    POST /api/magic  {moxfield|decklist}              -> cartas Magic
-    GET  /api/config                                  -> valores por defecto
+API:
+    GET  /api/snapshots                         histórico mensual del patrimonio
+    POST /api/snapshot                          guarda una categoría/mes
+    GET  /api/summary                           resumen + variación mensual
+    POST /api/monthly-summary?token=...         envía el resumen por WhatsApp
+    POST /api/bank            (PDF)             extracto -> gasto neto + liquidez
+    POST /api/wealthreader    {code,token}      banca automática (Wealth Reader)
+    POST /api/trade-republic  (PDF/CSV)         acciones / ETFs
+    GET  /api/steam?steamid=...                 skins CS:GO (Steam Market)
+    POST /api/magic           {moxfield|decklist}  cartas Magic (Scryfall)
+    GET/POST /api/cards                         lista de cartas guardada
+    POST /webhook/whatsapp                      ingesta de PDFs por WhatsApp
 """
 
+import base64
+import functools
 import hashlib
 import json
+import logging
 import os
 import re
 import tempfile
+import urllib.request
+from xml.sax.saxutils import escape as xml_escape
 
 from flask import Flask, jsonify, render_template, request
 
-from sources import bank, trade_republic, steam, moxfield, db, ingest, wealthreader
+from sources import (bank, trade_republic, steam, moxfield, db, ingest,
+                     wealthreader, patrimonio)
+from jobs.weekly_whatsapp import send_whatsapp
+
+APP_VERSION = "2026-06-r13-refactor"
+MONTH_RE = re.compile(r"^\d{4}-\d{2}$")
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
+log = logging.getLogger("patrimonio")
 
 app = Flask(__name__)
 app.config["MAX_CONTENT_LENGTH"] = 32 * 1024 * 1024
 
 _HERE = os.path.dirname(__file__)
-_CONFIG_PATH = os.path.join(_HERE, "config.json")
-_CONFIG_EXAMPLE = os.path.join(_HERE, "config.example.json")
+_CONFIG_PATHS = (os.path.join(_HERE, "config.json"), os.path.join(_HERE, "config.example.json"))
 
 
+# ---------------------------------------------------------------------------
+# Utilidades
+# ---------------------------------------------------------------------------
 def load_config():
     """Lee config.json; si no existe, usa config.example.json como respaldo."""
-    for path in (_CONFIG_PATH, _CONFIG_EXAMPLE):
+    for path in _CONFIG_PATHS:
         try:
             with open(path) as fh:
                 return json.load(fh)
@@ -45,9 +65,30 @@ def load_config():
     return {}
 
 
+def api_error(status=502):
+    """Decorador: convierte excepciones de una ruta en JSON {error} (no 500 crudo).
+
+    ValueError -> 400 (validación); el resto -> `status` (por defecto 502).
+    """
+    def decorator(fn):
+        @functools.wraps(fn)
+        def wrapper(*args, **kwargs):
+            try:
+                return fn(*args, **kwargs)
+            except ValueError as exc:
+                return jsonify({"error": str(exc)}), 400
+            except Exception as exc:  # noqa: BLE001
+                log.exception("Error en %s", fn.__name__)
+                return jsonify({"error": str(exc)}), status
+        return wrapper
+    return decorator
+
+
 def _save_upload(file_storage, suffixes):
-    """Guarda el archivo subido en un temporal y devuelve la ruta."""
-    name = (file_storage.filename or "").lower()
+    """Guarda el archivo subido en un temporal y devuelve la ruta (o ValueError)."""
+    if file_storage is None or not (file_storage.filename or ""):
+        raise ValueError("No se ha recibido ningún archivo.")
+    name = file_storage.filename.lower()
     if not name.endswith(suffixes):
         raise ValueError(f"El archivo debe ser {' o '.join(suffixes)}.")
     suffix = os.path.splitext(name)[1] or suffixes[0]
@@ -57,30 +98,32 @@ def _save_upload(file_storage, suffixes):
     return tmp.name
 
 
-_DATA_DIR = os.environ.get("PATRIMONIO_DATA_DIR") or os.path.join(_HERE, "data")
-_SNAPSHOTS = os.path.join(_DATA_DIR, "snapshots.json")
-
-
-def _read_json(path, default):
+def _process_upload(field, suffixes, handler):
+    """Guarda el adjunto, lo procesa con `handler(path)` y limpia el temporal."""
+    path = _save_upload(request.files.get(field), suffixes)
     try:
-        with open(path) as fh:
-            return json.load(fh)
-    except (OSError, ValueError):
-        return default
+        return jsonify(handler(path))
+    finally:
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
 
 
-def _write_json(path, obj):
-    os.makedirs(os.path.dirname(path), exist_ok=True)
-    with open(path, "w") as fh:
-        json.dump(obj, fh, indent=2, ensure_ascii=False)
+@app.after_request
+def _security_headers(resp):
+    resp.headers.setdefault("X-Content-Type-Options", "nosniff")
+    resp.headers.setdefault("X-Frame-Options", "SAMEORIGIN")
+    resp.headers.setdefault("Referrer-Policy", "same-origin")
+    return resp
 
 
+# ---------------------------------------------------------------------------
+# Páginas y meta
+# ---------------------------------------------------------------------------
 @app.route("/")
 def index():
     return render_template("index.html")
-
-
-APP_VERSION = "2026-06-r12-features"   # se sube en cada cambio para verificar el deploy
 
 
 @app.route("/health")
@@ -90,7 +133,6 @@ def health():
 
 @app.route("/api/version")
 def api_version():
-    """Para verificar qué build está realmente desplegado."""
     return jsonify({"version": APP_VERSION, "db": db.backend(),
                     "sources": ["banco", "trade_republic", "csgo", "magic"]})
 
@@ -98,84 +140,6 @@ def api_version():
 @app.route("/favicon.ico")
 def favicon():
     return app.send_static_file("favicon.svg")
-
-
-@app.route("/api/snapshots", methods=["GET"])
-def api_snapshots_get():
-    """Histórico mensual de patrimonio: { 'YYYY-MM': { categoria: valor } }."""
-    return jsonify(db.get_snapshots())
-
-
-def _record_snapshot(month, category, value):
-    db.set_snapshot(month, category, value)
-    return db.get_snapshots()
-
-
-@app.route("/api/snapshot", methods=["POST"])
-def api_snapshot_post():
-    """Guarda/actualiza el valor de una categoría para un mes concreto (en la DB)."""
-    body = request.get_json(silent=True) or {}
-    month = (body.get("month") or "").strip()
-    category = (body.get("category") or "").strip()
-    value = body.get("value")
-    if not re.match(r"^\d{4}-\d{2}$", month) or not category or not isinstance(value, (int, float)):
-        return jsonify({"error": "Datos inválidos (month=YYYY-MM, category, value)."}), 400
-    return jsonify({"ok": True, "snapshots": _record_snapshot(month, category, value)})
-
-
-@app.route("/api/snapshots/reset", methods=["POST"])
-def api_snapshots_reset():
-    db.reset_snapshots()
-    return jsonify({"ok": True})
-
-
-def _patrimonio_summary():
-    """Total del último mes, total del mes anterior, variación y flujos."""
-    snaps = db.get_snapshots()
-    months = sorted(snaps.keys())
-    if not months:
-        return None
-    def total(m):
-        return round(sum(v for k, v in snaps[m].items() if not k.startswith("_flow:")), 2)
-    last = months[-1]
-    cur = total(last)
-    prev = total(months[-2]) if len(months) > 1 else None
-    delta = round(cur - prev, 2) if prev is not None else None
-    pct = round((cur - prev) / prev * 100, 1) if prev else None
-    flows = snaps[last]
-    return {"month": last, "total": cur, "prev": prev, "delta": delta, "pct": pct,
-            "gastos": flows.get("_flow:gastos"), "ganancias": flows.get("_flow:ganancias"),
-            "categories": {k: v for k, v in snaps[last].items() if not k.startswith("_flow:")}}
-
-
-@app.route("/api/summary")
-def api_summary():
-    """Resumen de patrimonio + variación mensual (para la web y el resumen WhatsApp)."""
-    return jsonify(_patrimonio_summary() or {})
-
-
-@app.route("/api/monthly-summary", methods=["GET", "POST"])
-def api_monthly_summary():
-    """Envía por WhatsApp el patrimonio del mes y su variación (cron mensual)."""
-    expected = os.environ.get("SUMMARY_TOKEN", "").strip()
-    if expected and request.args.get("token", "") != expected:
-        return jsonify({"error": "No autorizado."}), 403
-    s = _patrimonio_summary()
-    if not s:
-        return jsonify({"error": "Sin datos."}), 404
-    eur = lambda n: f"{n:,.2f} €".replace(",", "X").replace(".", ",").replace("X", ".")
-    lines = [f"💼 *Tu patrimonio* ({s['month']})", "", f"Total: *{eur(s['total'])}*"]
-    if s["pct"] is not None:
-        arrow = "📈" if s["delta"] >= 0 else "📉"
-        lines.append(f"{arrow} {'+' if s['delta'] >= 0 else ''}{eur(s['delta'])} ({s['pct']:+.1f}%) vs mes anterior")
-    for k, v in sorted(s["categories"].items(), key=lambda x: -x[1]):
-        lines.append(f"• {k}: {eur(v)}")
-    if s.get("ganancias") is not None:
-        lines.append(f"\n🟢 Ingresos: {eur(s['ganancias'])}   🔴 Gastos: {eur(s.get('gastos') or 0)}")
-    lines.append("\nMi patrimonio · resumen mensual")
-    from jobs.weekly_whatsapp import send_whatsapp
-    sent = send_whatsapp("\n".join(lines))
-    return jsonify({"sent": bool(sent), "summary": s})
 
 
 @app.route("/api/config")
@@ -188,22 +152,56 @@ def api_config():
     })
 
 
-def _file_route(field, suffixes, handler):
-    f = request.files.get(field)
-    if f is None or f.filename == "":
-        return jsonify({"error": "No se ha recibido ningún archivo."}), 400
-    try:
-        path = _save_upload(f, suffixes)
-    except ValueError as exc:
-        return jsonify({"error": str(exc)}), 400
-    try:
-        return jsonify(handler(path))
-    except Exception as exc:  # noqa: BLE001
-        return jsonify({"error": f"No se pudo procesar: {exc}"}), 500
-    finally:
-        os.unlink(path)
+# ---------------------------------------------------------------------------
+# Snapshots / resumen
+# ---------------------------------------------------------------------------
+@app.route("/api/snapshots")
+def api_snapshots_get():
+    """Histórico mensual de patrimonio: { 'YYYY-MM': { categoria: valor } }."""
+    return jsonify(db.get_snapshots())
 
 
+@app.route("/api/snapshot", methods=["POST"])
+def api_snapshot_post():
+    """Guarda/actualiza el valor de una categoría para un mes concreto."""
+    body = request.get_json(silent=True) or {}
+    month = (body.get("month") or "").strip()
+    category = (body.get("category") or "").strip()
+    value = body.get("value")
+    if not MONTH_RE.match(month) or not category or not isinstance(value, (int, float)):
+        return jsonify({"error": "Datos inválidos (month=YYYY-MM, category, value)."}), 400
+    db.set_snapshot(month, category, value)
+    return jsonify({"ok": True, "snapshots": db.get_snapshots()})
+
+
+@app.route("/api/snapshots/reset", methods=["POST"])
+def api_snapshots_reset():
+    db.reset_snapshots()
+    return jsonify({"ok": True})
+
+
+@app.route("/api/summary")
+def api_summary():
+    """Resumen de patrimonio + variación mensual (web y resumen WhatsApp)."""
+    return jsonify(patrimonio.summary(db.get_snapshots()) or {})
+
+
+@app.route("/api/monthly-summary", methods=["GET", "POST"])
+def api_monthly_summary():
+    """Envía por WhatsApp el patrimonio y su variación (cron semanal)."""
+    expected = os.environ.get("SUMMARY_TOKEN", "").strip()
+    if expected and request.args.get("token", "") != expected:
+        return jsonify({"error": "No autorizado."}), 403
+    s = patrimonio.summary(db.get_snapshots())
+    if not s:
+        return jsonify({"error": "Sin datos."}), 404
+    sent = send_whatsapp(patrimonio.whatsapp_message(s))
+    return jsonify({"sent": bool(sent), "summary": s})
+
+
+# ---------------------------------------------------------------------------
+# Fuentes
+# ---------------------------------------------------------------------------
 def _bank_and_persist(path):
     data = bank.analyze(path)
     ingest.persist_bank_aggregates(data.get("aggregates") or {})
@@ -211,41 +209,38 @@ def _bank_and_persist(path):
 
 
 @app.route("/api/bank", methods=["POST"])
+@api_error(500)
 def api_bank():
-    return _file_route("file", (".pdf",), _bank_and_persist)
+    return _process_upload("file", (".pdf",), _bank_and_persist)
+
+
+@app.route("/api/trade-republic", methods=["POST"])
+@api_error(500)
+def api_trade_republic():
+    return _process_upload("file", (".pdf", ".csv"), trade_republic.parse)
 
 
 @app.route("/api/wealthreader", methods=["POST"])
+@api_error()
 def api_wealthreader():
     """Banca automática: trae movimientos del banco vía Wealth Reader y los clasifica."""
     body = request.get_json(silent=True) or {}
     code = (body.get("code") or "").strip()
     token = (body.get("token") or "").strip()
     if not code or not token:
-        return jsonify({"error": "Faltan 'code' (banco) y 'token' (del widget de Wealth Reader)."}), 400
-    try:
-        data = wealthreader.analyze(code, token, body.get("date_from"), body.get("date_to"))
-        ingest.persist_bank_aggregates(data.get("aggregates") or {})
-        return jsonify(data)
-    except Exception as exc:  # noqa: BLE001
-        return jsonify({"error": str(exc)}), 502
+        raise ValueError("Faltan 'code' (banco) y 'token' (del widget de Wealth Reader).")
+    data = wealthreader.analyze(code, token, body.get("date_from"), body.get("date_to"))
+    ingest.persist_bank_aggregates(data.get("aggregates") or {})
+    return jsonify(data)
 
 
-@app.route("/api/trade-republic", methods=["POST"])
-def api_trade_republic():
-    return _file_route("file", (".pdf", ".csv"), trade_republic.parse)
-
-
-def _cached_daily(key, compute):
-    """Devuelve la valoración cacheada del día; si no hay, la calcula y la guarda.
-
-    Evita golpear Steam/Scryfall en cada visita (y al compartir con amigos): se
-    valora una vez al día por entrada.
-    """
-    hit = db.cache_get_today(key)
-    if hit is not None:
-        hit["cached"] = True
-        return hit
+def _cached_daily(key, compute, refresh=False):
+    """Valoración cacheada una vez al día (evita golpear Steam/Scryfall por visita)."""
+    if not refresh:
+        hit = db.cache_get_today(key)
+        if hit is not None:
+            hit["cached"] = True
+            return hit
     data = compute()
     db.cache_put(key, data)
     data["cached"] = False
@@ -253,49 +248,34 @@ def _cached_daily(key, compute):
 
 
 @app.route("/api/steam")
+@api_error()
 def api_steam():
     steamid = (request.args.get("steamid") or load_config().get("steam", {}).get("steamid64", "")).strip()
     currency = request.args.get("currency", "eur")
     if not steamid or steamid.startswith("TU_"):
-        return jsonify({"error": "Indica tu SteamID64 (inventario en público)."}), 400
-    nocache = request.args.get("refresh") == "1"
-    try:
-        key = f"steam:{steamid}:{currency}"
-        if nocache:
-            data = steam.analyze(steamid, currency)
-            db.cache_put(key, data)
-        else:
-            data = _cached_daily(key, lambda: steam.analyze(steamid, currency))
-        return jsonify(data)
-    except Exception as exc:  # noqa: BLE001
-        return jsonify({"error": str(exc)}), 502
+        raise ValueError("Indica tu SteamID64 (inventario en público).")
+    key = f"steam:{steamid}:{currency}"
+    return jsonify(_cached_daily(key, lambda: steam.analyze(steamid, currency),
+                                 refresh=request.args.get("refresh") == "1"))
 
 
 @app.route("/api/magic", methods=["POST"])
+@api_error()
 def api_magic():
     body = request.get_json(silent=True) or {}
     reference = (body.get("moxfield") or "").strip()
     decklist = body.get("decklist") or ""
     if not reference and not decklist.strip():
-        return jsonify({"error": "Indica una URL/ID de Moxfield o pega una decklist."}), 400
-    nocache = bool(body.get("refresh"))
-    # Guarda la lista de cartas para reutilizarla (carga al volver, watchlist).
+        raise ValueError("Indica una URL/ID de Moxfield o pega una decklist.")
     db.set_setting("magic_cards", {"reference": reference, "decklist": decklist})
-    try:
-        key = "magic:" + hashlib.sha1((reference + "|" + decklist).encode()).hexdigest()
-        if nocache:
-            data = moxfield.analyze(reference=reference, decklist=decklist)
-            db.cache_put(key, data)
-        else:
-            data = _cached_daily(key, lambda: moxfield.analyze(reference=reference, decklist=decklist))
-        return jsonify(data)
-    except Exception as exc:  # noqa: BLE001
-        return jsonify({"error": str(exc)}), 502
+    key = "magic:" + hashlib.sha1((reference + "|" + decklist).encode()).hexdigest()
+    return jsonify(_cached_daily(key, lambda: moxfield.analyze(reference=reference, decklist=decklist),
+                                 refresh=bool(body.get("refresh"))))
 
 
 @app.route("/api/cards", methods=["GET", "POST"])
 def api_cards():
-    """Lista de cartas guardada (para precargar/guardar el gestor de cartas)."""
+    """Lista de cartas guardada (precarga/guarda el gestor de cartas)."""
     if request.method == "POST":
         body = request.get_json(silent=True) or {}
         db.set_setting("magic_cards", {"reference": (body.get("reference") or "").strip(),
@@ -305,39 +285,27 @@ def api_cards():
 
 
 # ---------------------------------------------------------------------------
-# WhatsApp entrante: recibir y procesar PDFs enviados por WhatsApp (Twilio).
+# WhatsApp entrante (Twilio): ingesta de PDFs adjuntos
 # ---------------------------------------------------------------------------
-import base64                       # noqa: E402
-import urllib.request               # noqa: E402
-
-
-def _process_document(path):
-    return ingest.process(path)["summary"]
-
-
 def _download_twilio_media(url):
     sid = os.environ.get("TWILIO_ACCOUNT_SID", "")
     token = os.environ.get("TWILIO_AUTH_TOKEN", "")
     req = urllib.request.Request(url)
     if sid and token:
-        auth = base64.b64encode(f"{sid}:{token}".encode()).decode()
-        req.add_header("Authorization", "Basic " + auth)
+        req.add_header("Authorization", "Basic " + base64.b64encode(f"{sid}:{token}".encode()).decode())
     with urllib.request.urlopen(req, timeout=40) as resp:
         return resp.read()
 
 
 def _twiml(message):
-    xml = ("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
-           f"<Response><Message>{message}</Message></Response>")
+    xml = (f'<?xml version="1.0" encoding="UTF-8"?>'
+           f"<Response><Message>{xml_escape(message)}</Message></Response>")
     return app.response_class(xml, mimetype="text/xml")
 
 
 def _webhook_authorized():
-    """Si WHATSAPP_WEBHOOK_TOKEN está definido, exige ?token=... (endpoint público)."""
     expected = os.environ.get("WHATSAPP_WEBHOOK_TOKEN", "").strip()
-    if not expected:
-        return True
-    return request.args.get("token", "") == expected
+    return not expected or request.args.get("token", "") == expected
 
 
 @app.route("/webhook/whatsapp", methods=["POST"])
@@ -350,22 +318,22 @@ def whatsapp_inbound():
     except ValueError:
         num_media = 0
     if not num_media:
-        return _twiml("👋 Envíame el PDF del banco, de Trade Republic o de Nexo (o un CSV) "
-                      "y lo añado a tu patrimonio. También valoro tus cartas y skins desde la web.")
-
+        return _twiml("👋 Envíame el PDF del banco o de Trade Republic (o un CSV) y lo añado "
+                      "a tu patrimonio. También valoro cartas y skins desde la web.")
     replies = []
     for i in range(num_media):
-        ctype = request.form.get(f"MediaContentType{i}", "")
         url = request.form.get(f"MediaUrl{i}", "")
         if not url:
             continue
-        suffix = ".csv" if "csv" in ctype or "excel" in ctype else ".pdf"
+        ctype = request.form.get(f"MediaContentType{i}", "")
+        suffix = ".csv" if ("csv" in ctype or "excel" in ctype) else ".pdf"
         tmp = tempfile.NamedTemporaryFile(suffix=suffix, delete=False)
         try:
             tmp.write(_download_twilio_media(url))
             tmp.close()
-            replies.append(_process_document(tmp.name))
+            replies.append(ingest.process(tmp.name)["summary"])
         except Exception as exc:  # noqa: BLE001
+            log.exception("Webhook: fallo procesando adjunto")
             replies.append(f"⚠️ No pude procesar un adjunto: {exc}")
         finally:
             try:
@@ -375,15 +343,15 @@ def whatsapp_inbound():
     return _twiml("\n".join(replies) or "No encontré adjuntos válidos.")
 
 
-# Programador en proceso para la versión desplegada (instancia siempre activa).
+# Programador en proceso (solo en instancia siempre activa).
 if os.environ.get("ENABLE_SCHEDULER") == "1":
     try:
         from jobs.scheduler import start_scheduler
         start_scheduler()
-    except Exception as exc:  # noqa: BLE001
-        print("No se pudo iniciar el scheduler:", exc)
+    except Exception:  # noqa: BLE001
+        log.exception("No se pudo iniciar el scheduler")
 
 
 if __name__ == "__main__":
-    port = int(os.environ.get("PORT", "5000"))
-    app.run(host="0.0.0.0", port=port, debug=True)
+    app.run(host="0.0.0.0", port=int(os.environ.get("PORT", "5000")),
+            debug=os.environ.get("FLASK_DEBUG") == "1")

--- a/app/pytest.ini
+++ b/app/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = tests
+addopts = -q

--- a/app/requirements-dev.txt
+++ b/app/requirements-dev.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+pytest>=8.0     # batería de tests

--- a/app/sources/moxfield.py
+++ b/app/sources/moxfield.py
@@ -169,6 +169,15 @@ def price_cards(cards):
             p = card.get("prices", {})
             pr = {k: (float(p[k]) if p.get(k) else None)
                   for k in ("eur", "usd", "eur_foil", "usd_foil")}
+            # Metadatos para una vista rica (miniatura, rareza, tipo). Las cartas de
+            # doble cara llevan las imágenes dentro de 'card_faces'.
+            faces = card.get("card_faces") or []
+            imgs = card.get("image_uris") or (faces[0].get("image_uris") if faces else {}) or {}
+            pr["image"] = imgs.get("small") or imgs.get("normal")
+            pr["image_large"] = imgs.get("normal") or imgs.get("large") or imgs.get("small")
+            pr["rarity"] = card.get("rarity")
+            pr["type"] = card.get("type_line")
+            pr["set_name"] = card.get("set_name")
             if card.get("id"):
                 found[("id", card["id"])] = pr
             if card.get("set") and card.get("collector_number"):
@@ -227,7 +236,10 @@ def analyze(reference=None, decklist=None):
         positions.append(Position(
             source=SOURCE, category=CATEGORY, name=c["name"], quantity=c["quantity"],
             unit_value=unit, value=round(unit * c["quantity"], 2), currency=cur,
-            extra={"deck": deck_name, "edition": edition, "foil": foil, "tag": tag},
+            extra={"deck": deck_name, "edition": edition, "foil": foil, "tag": tag,
+                   "image": pr.get("image"), "image_large": pr.get("image_large"),
+                   "rarity": pr.get("rarity"), "type": pr.get("type"),
+                   "set_name": pr.get("set_name"), "usd_note": usd_note.strip()},
         ).finalize())
     if usd_converted:
         warnings.append(f"{usd_converted} carta(s) sin precio EUR: convertidas de USD a € al cambio del día.")

--- a/app/sources/patrimonio.py
+++ b/app/sources/patrimonio.py
@@ -1,0 +1,59 @@
+"""
+Dominio del patrimonio: cálculo del resumen mensual y su mensaje de WhatsApp.
+
+Separa la lógica de negocio (a partir de los snapshots) de la capa web (app.py).
+Las claves con prefijo '_flow:' (gastos/ganancias/inversión) son flujos del mes,
+no patrimonio, y no suman al total.
+"""
+
+FLOW_PREFIX = "_flow:"
+
+
+def is_flow(key):
+    return key.startswith(FLOW_PREFIX)
+
+
+def month_total(month_snapshot):
+    """Suma de las categorías de patrimonio de un mes (excluye flujos)."""
+    return round(sum(v for k, v in month_snapshot.items() if not is_flow(k)), 2)
+
+
+def summary(snapshots):
+    """Resumen del último mes: total, total previo, variación y flujos.
+
+    snapshots: { 'YYYY-MM': { categoria|_flow:x : valor } }. None si no hay datos.
+    """
+    months = sorted(snapshots or {})
+    if not months:
+        return None
+    last = months[-1]
+    cur = month_total(snapshots[last])
+    prev = month_total(snapshots[months[-2]]) if len(months) > 1 else None
+    delta = round(cur - prev, 2) if prev is not None else None
+    pct = round((cur - prev) / prev * 100, 1) if prev else None
+    flows = snapshots[last]
+    return {
+        "month": last, "total": cur, "prev": prev, "delta": delta, "pct": pct,
+        "gastos": flows.get("_flow:gastos"), "ganancias": flows.get("_flow:ganancias"),
+        "categories": {k: v for k, v in flows.items() if not is_flow(k)},
+    }
+
+
+def eur(n):
+    """Formatea un número como '1.234,56 €' (formato español)."""
+    return f"{n:,.2f} €".replace(",", "\x00").replace(".", ",").replace("\x00", ".")
+
+
+def whatsapp_message(s):
+    """Construye el mensaje de WhatsApp del resumen de patrimonio."""
+    lines = [f"💼 *Tu patrimonio* ({s['month']})", "", f"Total: *{eur(s['total'])}*"]
+    if s["pct"] is not None:
+        arrow = "📈" if s["delta"] >= 0 else "📉"
+        sign = "+" if s["delta"] >= 0 else ""
+        lines.append(f"{arrow} {sign}{eur(s['delta'])} ({s['pct']:+.1f}%) vs periodo anterior")
+    for k, v in sorted(s["categories"].items(), key=lambda x: -x[1]):
+        lines.append(f"• {k}: {eur(v)}")
+    if s.get("ganancias") is not None:
+        lines.append(f"\n🟢 Ingresos: {eur(s['ganancias'])}   🔴 Gastos: {eur(s.get('gastos') or 0)}")
+    lines.append("\nMi patrimonio · resumen automático")
+    return "\n".join(lines)

--- a/app/static/app.js
+++ b/app/static/app.js
@@ -2,6 +2,10 @@
 
 const $ = (s, r = document) => r.querySelector(s);
 const $$ = (s, r = document) => [...r.querySelectorAll(s)];
+// Escapa texto antes de inyectarlo en innerHTML (evita XSS desde nombres de
+// cartas, items de Steam, conceptos del banco, etc.). Sirve para texto y atributos.
+const esc = (v) => String(v == null ? "" : v).replace(/[&<>"']/g, (c) =>
+  ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
 const money = (n, cur = "EUR") =>
   (n < 0 ? "-" : "") + (cur === "USD" ? "$" : "€") +
   Math.abs(n).toLocaleString("es-ES", { minimumFractionDigits: 2, maximumFractionDigits: 2 });
@@ -40,7 +44,7 @@ function renderSummary() {
   let html = `<div class="kpi big"><div class="label">Patrimonio total</div>
               <div class="val pos">${money(total)}</div>${deltaHtml}</div>`;
   for (const [label, v] of entries.sort((a, b) => b[1] - a[1])) {
-    html += `<div class="kpi"><div class="label">${label}</div><div class="val">${money(v)}</div></div>`;
+    html += `<div class="kpi"><div class="label">${esc(label)}</div><div class="val">${money(v)}</div></div>`;
   }
   if (FLOWS.ganancias !== null) {
     html += `<div class="kpi"><div class="label">Ganancias del mes</div>
@@ -83,7 +87,7 @@ function setStatus(target, msg, err) { const s = statusEl(target); s.textContent
 
 function warningsHtml(warnings) {
   if (!warnings || !warnings.length) return "";
-  return warnings.map((w) => `<p class="warn">⚠️ ${w}</p>`).join("");
+  return warnings.map((w) => `<p class="warn">⚠️ ${esc(w)}</p>`).join("");
 }
 
 // ---- subida genérica (Trade Republic, Nexo, Banco) ---------------------
@@ -113,10 +117,10 @@ $$("form[data-upload]").forEach((form) => {
 function renderPositions(data, target) {
   const cur = data.currency || "EUR";
   const rows = data.positions.map((p) => {
-    const icon = p.extra && p.extra.icon ? `<img class="thumb" src="${p.extra.icon}">` : "";
+    const icon = p.extra && p.extra.icon ? `<img class="thumb" src="${esc(p.extra.icon)}">` : "";
     const sub = p.extra && (p.extra.tag || p.extra.isin || p.extra.asset || p.extra.deck || p.extra.type) || "";
     return `<tr>
-      <td>${icon}${p.name}${sub ? ` <span class="tag">${sub}</span>` : ""}</td>
+      <td>${icon}${esc(p.name)}${sub ? ` <span class="tag">${esc(sub)}</span>` : ""}</td>
       <td class="num muted">${p.quantity.toLocaleString("es-ES")}</td>
       <td class="num muted">${p.unit_value ? money(p.unit_value, p.currency) : "—"}</td>
       <td class="num">${money(p.value, p.currency)}</td>
@@ -128,7 +132,7 @@ function renderPositions(data, target) {
       <thead><tr><th>Activo</th><th class="num">Cantidad</th>
         <th class="num">Precio ud.</th><th class="num">Valor</th></tr></thead>
       <tbody>${rows || `<tr><td colspan="4" class="muted">Sin posiciones.</td></tr>`}</tbody>
-      <tfoot><tr><td colspan="3">Total ${data.source}</td>
+      <tfoot><tr><td colspan="3">Total ${esc(data.source)}</td>
         <td class="num pos">${money(data.total, cur)}</td></tr></tfoot>
     </table>`;
   if (window.AppFX) AppFX.onRender(target);
@@ -204,7 +208,7 @@ function renderCards() {
   if (!CARDS.length) { el.innerHTML = `<p class="hint">Aún no hay cartas. Añade una arriba o importa una decklist.</p>`; return; }
   el.innerHTML = CARDS.map((c, i) => `<div class="card-row">
     <span class="card-q">${c.qty}×</span>
-    <span class="card-n">${c.name}${c.set ? ` <span class="tag">${c.set.toUpperCase()}${c.cn ? " " + c.cn : ""}</span>` : ""}${c.foil ? ` <span class="tag tag-foil">foil</span>` : ""}</span>
+    <span class="card-n">${esc(c.name)}${c.set ? ` <span class="tag">${esc(c.set.toUpperCase())}${c.cn ? " " + esc(c.cn) : ""}</span>` : ""}${c.foil ? ` <span class="tag tag-foil">foil</span>` : ""}</span>
     <button type="button" class="card-del" data-i="${i}" aria-label="Quitar">×</button>
   </div>`).join("");
   $$(".card-del", el).forEach((b) => b.addEventListener("click", () => { CARDS.splice(+b.dataset.i, 1); renderCards(); saveCards(); }));
@@ -323,7 +327,7 @@ function bankRender() {
   const rows = Object.entries(c.cats).sort((a, b) => (b[1].gross - b[1].refund) - (a[1].gross - a[1].refund));
   $("#catTable tbody").innerHTML = rows.map(([cat, v]) => {
     const net = v.gross - v.refund, pct = c.net ? (net / c.net) * 100 : 0;
-    return `<tr><td>${cat}</td><td class="num muted">${money(-v.gross)}</td>
+    return `<tr><td>${esc(cat)}</td><td class="num muted">${money(-v.gross)}</td>
       <td class="num ${v.refund ? "pos" : "muted"}">${v.refund ? money(v.refund) : "—"}</td>
       <td class="num neg">${money(-net)}</td>
       <td class="num">${pct.toFixed(1)}%<div class="bar"><span style="width:${Math.max(0, pct)}%"></span></div></td></tr>`;
@@ -336,11 +340,11 @@ function bankRender() {
     const none = (sel === null || sel === undefined) ? " selected" : "";
     return `<option value=""${none}>— Ingreso real (no devolución) —</option>` +
       BANK.transactions.filter(isExp).map((e) =>
-        `<option value="${e.id}"${e.id === sel ? " selected" : ""}>${e.date} · ${e.concept} (${money(e.amount)})</option>`).join("");
+        `<option value="${e.id}"${e.id === sel ? " selected" : ""}>${esc(e.date)} · ${esc(e.concept)} (${money(e.amount)})</option>`).join("");
   };
   $("#bizumTable tbody").innerHTML = bizums.length ? bizums.map((b) => {
     const flag = b.recurring_income ? ` <span class="tag">posible ingreso recurrente</span>` : "";
-    return `<tr><td>${b.date}${flag}</td><td class="num pos">${money(b.amount)}</td>
+    return `<tr><td>${esc(b.date)}${flag}</td><td class="num pos">${money(b.amount)}</td>
       <td><select data-bizum="${b.id}">${opts(LINKS[b.id])}</select></td></tr>`;
   }).join("") : `<tr><td colspan="3" class="muted">No hay bizums recibidos.</td></tr>`;
   $$("#bizumTable select").forEach((s) => s.addEventListener("change", () => {

--- a/app/static/app.js
+++ b/app/static/app.js
@@ -203,16 +203,43 @@ function parseDecklistJS(text) {
   return out;
 }
 
+let CARD_Q = "";
+
 function renderCards() {
   const el = $("#cardList");
-  if (!CARDS.length) { el.innerHTML = `<p class="hint">Aún no hay cartas. Añade una arriba o importa una decklist.</p>`; return; }
-  el.innerHTML = CARDS.map((c, i) => `<div class="card-row">
+  const tools = $("#cardTools"), pill = $("#cardCount");
+  const totalQty = CARDS.reduce((s, c) => s + (c.qty || 1), 0);
+  if (tools) tools.hidden = CARDS.length <= 8;
+  if (pill) { pill.hidden = !CARDS.length; pill.textContent = `${CARDS.length} líneas · ${totalQty} cartas`; }
+  if (!CARDS.length) {
+    el.innerHTML = `<p class="hint">Aún no hay cartas. Añade una arriba o importa una decklist.</p>`;
+    return;
+  }
+  const q = CARD_Q.toLowerCase();
+  // Conserva el índice real en CARDS para poder borrar tras filtrar.
+  const rows = CARDS.map((c, i) => [c, i]).filter(([c]) =>
+    !q || (c.name + " " + (c.set || "")).toLowerCase().includes(q));
+  if (!rows.length) { el.innerHTML = `<p class="hint">Sin coincidencias para «${esc(CARD_Q)}».</p>`; return; }
+  el.innerHTML = rows.map(([c, i]) => `<div class="card-row">
     <span class="card-q">${c.qty}×</span>
     <span class="card-n">${esc(c.name)}${c.set ? ` <span class="tag">${esc(c.set.toUpperCase())}${c.cn ? " " + esc(c.cn) : ""}</span>` : ""}${c.foil ? ` <span class="tag tag-foil">foil</span>` : ""}</span>
     <button type="button" class="card-del" data-i="${i}" aria-label="Quitar">×</button>
   </div>`).join("");
-  $$(".card-del", el).forEach((b) => b.addEventListener("click", () => { CARDS.splice(+b.dataset.i, 1); renderCards(); saveCards(); }));
 }
+
+// Borrado por delegación (un único listener, robusto con miles de filas).
+$("#cardList").addEventListener("click", (ev) => {
+  const b = ev.target.closest(".card-del");
+  if (!b) return;
+  CARDS.splice(+b.dataset.i, 1);
+  renderCards(); saveCards();
+});
+const cardSearch = $("#cardSearch");
+if (cardSearch) cardSearch.addEventListener("input", (e) => { CARD_Q = e.target.value; renderCards(); });
+const cardClear = $("#cardClear");
+if (cardClear) cardClear.addEventListener("click", () => {
+  if (CARDS.length && confirm("¿Vaciar toda la lista de cartas?")) { CARDS = []; CARD_Q = ""; if (cardSearch) cardSearch.value = ""; renderCards(); saveCards(); }
+});
 
 function saveCards() {
   fetch("/api/cards", { method: "POST", headers: { "Content-Type": "application/json" },
@@ -248,11 +275,154 @@ $("#valuarBtn").addEventListener("click", async () => {
     });
     const json = await res.json();
     if (!res.ok) throw new Error(json.error || "Error");
-    setStatus(target, json.deck ? "Mazo: " + json.deck : "");
-    renderPositions(json, target);
+    setStatus(target, json.deck && json.deck !== "Decklist" ? "Mazo: " + json.deck : "");
+    renderMagic(json, target);
   } catch (e) { setStatus(target, e.message, true); }
   finally { btn.disabled = false; }
 });
+
+// ---- Magic: vista rica de la colección (galería + buscador + orden) ------
+// Lista potencialmente enorme: sin paginación, pero con búsqueda/orden
+// instantáneos y renderizado progresivo (chunks al hacer scroll) + imágenes
+// perezosas, para que el DOM no crezca de golpe.
+const MAGIC = { all: [], view: [], shown: 0, chunk: 60, q: "", sort: "value", foil: false,
+               layout: "grid", io: null, currency: "EUR" };
+
+function magicStats(list) {
+  const units = list.reduce((s, p) => s + (p.quantity || 0), 0);
+  const total = list.reduce((s, p) => s + (p.value || 0), 0);
+  const foils = list.filter((p) => p.extra && p.extra.foil).reduce((s, p) => s + (p.quantity || 0), 0);
+  const top = list.reduce((m, p) => (p.unit_value || 0) > (m.unit_value || 0) ? p : m, list[0] || {});
+  return [
+    ["Cartas", units.toLocaleString("es-ES")],
+    ["Valor total", money(total)],
+    ["Más cara", top && top.unit_value ? money(top.unit_value) : "—", top && top.name ? esc(top.name) : ""],
+    ["Foils", foils.toLocaleString("es-ES")],
+  ];
+}
+
+function magicApplyFilters() {
+  const q = MAGIC.q.toLowerCase();
+  let list = MAGIC.all.filter((p) => {
+    if (MAGIC.foil && !(p.extra && p.extra.foil)) return false;
+    if (!q) return true;
+    const hay = [p.name, p.extra && p.extra.edition, p.extra && p.extra.set_name, p.extra && p.extra.type]
+      .filter(Boolean).join(" ").toLowerCase();
+    return hay.includes(q);
+  });
+  const by = {
+    value: (a, b) => (b.value || 0) - (a.value || 0),
+    unit: (a, b) => (b.unit_value || 0) - (a.unit_value || 0),
+    qty: (a, b) => (b.quantity || 0) - (a.quantity || 0),
+    name: (a, b) => (a.name || "").localeCompare(b.name || "", "es"),
+  }[MAGIC.sort] || (() => 0);
+  list.sort(by);
+  MAGIC.view = list;
+  MAGIC.shown = 0;
+}
+
+function magicTile(p) {
+  const x = p.extra || {};
+  const img = x.image || x.image_large || "";
+  const rarity = x.rarity ? `<span class="m-rar r-${esc(x.rarity)}">${esc(x.rarity[0].toUpperCase())}</span>` : "";
+  const ed = [x.edition, x.set_name].filter(Boolean)[0] || "";
+  const qty = (p.quantity || 1);
+  return `<article class="mcard${x.foil ? " is-foil" : ""}">
+    <div class="m-thumb">
+      ${img ? `<img loading="lazy" src="${esc(img)}" alt="${esc(p.name)}">` : `<div class="m-noimg">🃏</div>`}
+      ${qty > 1 ? `<span class="m-qty">×${qty}</span>` : ""}
+      ${x.foil ? `<span class="m-foil">foil</span>` : ""}
+    </div>
+    <div class="m-info">
+      <div class="m-name" title="${esc(p.name)}">${esc(p.name)}</div>
+      <div class="m-sub">${rarity}<span class="m-ed">${esc(ed)}</span></div>
+      <div class="m-prices">
+        <span class="m-unit">${p.unit_value ? money(p.unit_value) : "—"}${x.usd_note ? ` <span class="m-usd">${esc(x.usd_note)}</span>` : ""}</span>
+        <span class="m-val">${money(p.value)}</span>
+      </div>
+    </div>
+  </article>`;
+}
+
+function magicRenderChunk(grid) {
+  const next = MAGIC.view.slice(MAGIC.shown, MAGIC.shown + MAGIC.chunk);
+  if (!next.length) return;
+  grid.insertAdjacentHTML("beforeend", next.map(magicTile).join(""));
+  MAGIC.shown += next.length;
+  const left = MAGIC.view.length - MAGIC.shown;
+  const count = grid.parentElement.querySelector(".m-count");
+  if (count) count.textContent = `Mostrando ${MAGIC.shown} de ${MAGIC.view.length} cartas` + (left ? " · sigue bajando" : "");
+}
+
+function magicRefresh(target) {
+  magicApplyFilters();
+  const grid = $("#magicGrid", target);
+  if (!grid) return;
+  grid.className = "m-grid" + (MAGIC.layout === "list" ? " is-list" : "");
+  grid.innerHTML = "";
+  const stats = $("#magicStats", target);
+  if (stats) stats.innerHTML = magicStats(MAGIC.view).map(([l, v, sub]) =>
+    `<div class="m-stat"><span class="m-stat-l">${l}</span><span class="m-stat-v">${v}</span>${sub ? `<span class="m-stat-s">${sub}</span>` : ""}</div>`).join("");
+  magicRenderChunk(grid);
+  if (window.AppFX) AppFX.onRender(grid);
+}
+
+function renderMagic(data, target) {
+  MAGIC.all = data.positions || [];
+  MAGIC.currency = data.currency || "EUR";
+  MAGIC.shown = 0;
+  if (MAGIC.io) { MAGIC.io.disconnect(); MAGIC.io = null; }
+  if (!MAGIC.all.length) {
+    target.innerHTML = `${warningsHtml(data.warnings)}<p class="hint">No se encontraron cartas para valorar.</p>`;
+    return;
+  }
+  target.innerHTML = `
+    <div class="m-statbar" id="magicStats"></div>
+    <div class="m-toolbar">
+      <div class="m-search"><span>🔎</span><input type="search" id="magicQ" placeholder="Buscar carta, set o tipo…" autocomplete="off"></div>
+      <select id="magicSort" aria-label="Ordenar">
+        <option value="value">Valor total ↓</option>
+        <option value="unit">Precio ud. ↓</option>
+        <option value="qty">Cantidad ↓</option>
+        <option value="name">Nombre A-Z</option>
+      </select>
+      <button type="button" class="m-chip" id="magicFoil" aria-pressed="false">✦ Solo foil</button>
+      <div class="m-views">
+        <button type="button" id="magicGridV" class="active" aria-label="Cuadrícula">▦</button>
+        <button type="button" id="magicListV" aria-label="Lista">≣</button>
+      </div>
+    </div>
+    <div id="magicGrid" class="m-grid"></div>
+    <p class="m-count hint"></p>
+    ${warningsHtml(data.warnings)}`;
+
+  $("#magicQ", target).addEventListener("input", (e) => { MAGIC.q = e.target.value; magicRefresh(target); });
+  $("#magicSort", target).addEventListener("change", (e) => { MAGIC.sort = e.target.value; magicRefresh(target); });
+  $("#magicFoil", target).addEventListener("click", (e) => {
+    MAGIC.foil = !MAGIC.foil; e.target.setAttribute("aria-pressed", MAGIC.foil); e.target.classList.toggle("active", MAGIC.foil);
+    magicRefresh(target);
+  });
+  const setView = (v) => {
+    MAGIC.layout = v;
+    $("#magicGridV", target).classList.toggle("active", v === "grid");
+    $("#magicListV", target).classList.toggle("active", v === "list");
+    magicRefresh(target);
+  };
+  $("#magicGridV", target).addEventListener("click", () => setView("grid"));
+  $("#magicListV", target).addEventListener("click", () => setView("list"));
+
+  magicRefresh(target);
+  // Renderizado progresivo: cuando el centinela entra en viewport, añade el siguiente bloque.
+  const sentinel = document.createElement("div");
+  sentinel.className = "m-sentinel";
+  $("#magicGrid", target).after(sentinel);
+  MAGIC.io = new IntersectionObserver((entries) => {
+    if (entries[0].isIntersecting) magicRenderChunk($("#magicGrid", target));
+  }, { rootMargin: "600px" });
+  MAGIC.io.observe(sentinel);
+
+  setContrib(data.category, data.total, data.month);   // suma al patrimonio consolidado
+}
 
 // Cargar lista de cartas guardada.
 fetch("/api/cards").then((r) => r.json()).then((j) => {

--- a/app/static/app.js
+++ b/app/static/app.js
@@ -281,12 +281,16 @@ $("#valuarBtn").addEventListener("click", async () => {
   finally { btn.disabled = false; }
 });
 
-// ---- Magic: vista rica de la colección (galería + buscador + orden) ------
-// Lista potencialmente enorme: sin paginación, pero con búsqueda/orden
-// instantáneos y renderizado progresivo (chunks al hacer scroll) + imágenes
-// perezosas, para que el DOM no crezca de golpe.
-const MAGIC = { all: [], view: [], shown: 0, chunk: 60, q: "", sort: "value", foil: false,
-               layout: "grid", io: null, currency: "EUR" };
+// ---- Magic: vista de la colección (tarjetas compactas + filtros + orden) --
+// Lista potencialmente enorme: sin paginación, pero con búsqueda/filtros/orden
+// instantáneos y renderizado progresivo (bloques al hacer scroll), para que el
+// DOM no crezca de golpe. Tarjetas sin imagen para aprovechar el espacio.
+const MAGIC = { all: [], view: [], shown: 0, chunk: 80, q: "", sort: "value", foil: false,
+               rar: new Set(), set: "", layout: "grid", io: null, currency: "EUR" };
+
+const RAR_ORDER = { mythic: 4, rare: 3, uncommon: 2, common: 1 };
+const RAR_DEFS = [["mythic", "Mítica"], ["rare", "Rara"], ["uncommon", "Infrecuente"], ["common", "Común"]];
+const setLabel = (x) => x.set_name || ((x.edition || "").split(" ")[0]) || "";
 
 function magicStats(list) {
   const units = list.reduce((s, p) => s + (p.quantity || 0), 0);
@@ -304,17 +308,25 @@ function magicStats(list) {
 function magicApplyFilters() {
   const q = MAGIC.q.toLowerCase();
   let list = MAGIC.all.filter((p) => {
-    if (MAGIC.foil && !(p.extra && p.extra.foil)) return false;
+    const x = p.extra || {};
+    if (MAGIC.foil && !x.foil) return false;
+    if (MAGIC.rar.size && !MAGIC.rar.has((x.rarity || "").toLowerCase())) return false;
+    if (MAGIC.set && setLabel(x) !== MAGIC.set) return false;
     if (!q) return true;
-    const hay = [p.name, p.extra && p.extra.edition, p.extra && p.extra.set_name, p.extra && p.extra.type]
-      .filter(Boolean).join(" ").toLowerCase();
+    const hay = [p.name, x.edition, x.set_name, x.type].filter(Boolean).join(" ").toLowerCase();
     return hay.includes(q);
   });
+  const rk = (p) => RAR_ORDER[((p.extra || {}).rarity || "").toLowerCase()] || 0;
   const by = {
     value: (a, b) => (b.value || 0) - (a.value || 0),
+    value_asc: (a, b) => (a.value || 0) - (b.value || 0),
     unit: (a, b) => (b.unit_value || 0) - (a.unit_value || 0),
+    unit_asc: (a, b) => (a.unit_value || 0) - (b.unit_value || 0),
     qty: (a, b) => (b.quantity || 0) - (a.quantity || 0),
     name: (a, b) => (a.name || "").localeCompare(b.name || "", "es"),
+    name_desc: (a, b) => (b.name || "").localeCompare(a.name || "", "es"),
+    rarity: (a, b) => rk(b) - rk(a) || (b.value || 0) - (a.value || 0),
+    set: (a, b) => setLabel(a.extra || {}).localeCompare(setLabel(b.extra || {}), "es"),
   }[MAGIC.sort] || (() => 0);
   list.sort(by);
   MAGIC.view = list;
@@ -323,23 +335,21 @@ function magicApplyFilters() {
 
 function magicTile(p) {
   const x = p.extra || {};
-  const img = x.image || x.image_large || "";
-  const rarity = x.rarity ? `<span class="m-rar r-${esc(x.rarity)}">${esc(x.rarity[0].toUpperCase())}</span>` : "";
-  const ed = [x.edition, x.set_name].filter(Boolean)[0] || "";
+  const r = (x.rarity || "").toLowerCase();
+  const rarity = r ? `<span class="m-rar r-${esc(r)}" title="${esc(x.rarity)}">${esc(x.rarity[0].toUpperCase())}</span>` : "";
+  const ed = setLabel(x) || (x.edition || "");
   const qty = (p.quantity || 1);
   return `<article class="mcard${x.foil ? " is-foil" : ""}">
-    <div class="m-thumb">
-      ${img ? `<img loading="lazy" src="${esc(img)}" alt="${esc(p.name)}">` : `<div class="m-noimg">🃏</div>`}
-      ${qty > 1 ? `<span class="m-qty">×${qty}</span>` : ""}
-      ${x.foil ? `<span class="m-foil">foil</span>` : ""}
+    <div class="m-head">
+      <span class="m-qty">×${qty}</span>
+      ${rarity}
+      ${x.foil ? `<span class="m-foil">✦ foil</span>` : ""}
     </div>
-    <div class="m-info">
-      <div class="m-name" title="${esc(p.name)}">${esc(p.name)}</div>
-      <div class="m-sub">${rarity}<span class="m-ed">${esc(ed)}</span></div>
-      <div class="m-prices">
-        <span class="m-unit">${p.unit_value ? money(p.unit_value) : "—"}${x.usd_note ? ` <span class="m-usd">${esc(x.usd_note)}</span>` : ""}</span>
-        <span class="m-val">${money(p.value)}</span>
-      </div>
+    <div class="m-name" title="${esc(p.name)}">${esc(p.name)}</div>
+    <div class="m-ed" title="${esc(x.edition || ed)}">${esc(ed)}</div>
+    <div class="m-prices">
+      <span class="m-unit">${p.unit_value ? money(p.unit_value) + " ud." : "—"}${x.usd_note ? ` <span class="m-usd">${esc(x.usd_note)}</span>` : ""}</span>
+      <span class="m-val">${money(p.value)}</span>
     </div>
   </article>`;
 }
@@ -371,36 +381,69 @@ function renderMagic(data, target) {
   MAGIC.all = data.positions || [];
   MAGIC.currency = data.currency || "EUR";
   MAGIC.shown = 0;
+  MAGIC.q = ""; MAGIC.set = ""; MAGIC.foil = false; MAGIC.sort = "value"; MAGIC.rar = new Set();
   if (MAGIC.io) { MAGIC.io.disconnect(); MAGIC.io = null; }
   if (!MAGIC.all.length) {
     target.innerHTML = `${warningsHtml(data.warnings)}<p class="hint">No se encontraron cartas para valorar.</p>`;
     return;
   }
+  // Opciones de set y rarezas presentes en la colección.
+  const setCounts = {}, rarCounts = {};
+  for (const p of MAGIC.all) {
+    const x = p.extra || {};
+    const sl = setLabel(x); if (sl) setCounts[sl] = (setCounts[sl] || 0) + 1;
+    const rr = (x.rarity || "").toLowerCase(); if (rr) rarCounts[rr] = (rarCounts[rr] || 0) + 1;
+  }
+  const setOpts = Object.keys(setCounts).sort((a, b) => a.localeCompare(b, "es"));
+  const setSelect = `<option value="">Todos los sets (${setOpts.length})</option>` +
+    setOpts.map((s) => `<option value="${esc(s)}">${esc(s)} · ${setCounts[s]}</option>`).join("");
+  const rarChips = RAR_DEFS.filter(([k]) => rarCounts[k]).map(([k, lbl]) =>
+    `<button type="button" class="m-rchip r-${k}" data-rar="${k}">${lbl} <b>${rarCounts[k]}</b></button>`).join("");
+
   target.innerHTML = `
     <div class="m-statbar" id="magicStats"></div>
     <div class="m-toolbar">
       <div class="m-search"><span>🔎</span><input type="search" id="magicQ" placeholder="Buscar carta, set o tipo…" autocomplete="off"></div>
       <select id="magicSort" aria-label="Ordenar">
-        <option value="value">Valor total ↓</option>
-        <option value="unit">Precio ud. ↓</option>
+        <optgroup label="Valor total"><option value="value">Mayor ↓</option><option value="value_asc">Menor ↑</option></optgroup>
+        <optgroup label="Precio unidad"><option value="unit">Mayor ↓</option><option value="unit_asc">Menor ↑</option></optgroup>
         <option value="qty">Cantidad ↓</option>
+        <option value="rarity">Rareza ↓</option>
+        <option value="set">Set A-Z</option>
         <option value="name">Nombre A-Z</option>
+        <option value="name_desc">Nombre Z-A</option>
       </select>
+      <select id="magicSet" aria-label="Set">${setSelect}</select>
       <button type="button" class="m-chip" id="magicFoil" aria-pressed="false">✦ Solo foil</button>
       <div class="m-views">
         <button type="button" id="magicGridV" class="active" aria-label="Cuadrícula">▦</button>
         <button type="button" id="magicListV" aria-label="Lista">≣</button>
       </div>
     </div>
+    ${rarChips ? `<div class="m-rars" id="magicRars">${rarChips}<button type="button" class="m-rclear" id="magicRarClear" hidden>Limpiar</button></div>` : ""}
     <div id="magicGrid" class="m-grid"></div>
     <p class="m-count hint"></p>
     ${warningsHtml(data.warnings)}`;
 
   $("#magicQ", target).addEventListener("input", (e) => { MAGIC.q = e.target.value; magicRefresh(target); });
   $("#magicSort", target).addEventListener("change", (e) => { MAGIC.sort = e.target.value; magicRefresh(target); });
+  $("#magicSet", target).addEventListener("change", (e) => { MAGIC.set = e.target.value; magicRefresh(target); });
   $("#magicFoil", target).addEventListener("click", (e) => {
     MAGIC.foil = !MAGIC.foil; e.target.setAttribute("aria-pressed", MAGIC.foil); e.target.classList.toggle("active", MAGIC.foil);
     magicRefresh(target);
+  });
+  $$(".m-rchip", target).forEach((b) => b.addEventListener("click", () => {
+    const k = b.dataset.rar;
+    if (MAGIC.rar.has(k)) MAGIC.rar.delete(k); else MAGIC.rar.add(k);
+    b.classList.toggle("active", MAGIC.rar.has(k));
+    const clr = $("#magicRarClear", target); if (clr) clr.hidden = !MAGIC.rar.size;
+    magicRefresh(target);
+  }));
+  const rarClear = $("#magicRarClear", target);
+  if (rarClear) rarClear.addEventListener("click", () => {
+    MAGIC.rar.clear();
+    $$(".m-rchip", target).forEach((b) => b.classList.remove("active"));
+    rarClear.hidden = true; magicRefresh(target);
   });
   const setView = (v) => {
     MAGIC.layout = v;

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -205,6 +205,88 @@ select:focus { outline: none; border-color: rgba(255, 255, 255, .5); }
 .card-del:hover { background: rgba(255, 107, 107, .22); }
 .tag-foil { color: #0a0a0c; background: var(--foil); border: 0; font-weight: 700; }
 
+/* ---------- Cabecera de lista + herramientas ---------- */
+.list-head { display: flex; align-items: center; justify-content: space-between; gap: 12px; flex-wrap: wrap; margin: 22px 0 6px; }
+.list-head h3 { margin: 0; display: inline-flex; align-items: center; gap: 10px; }
+.count-pill { font: 600 11px "Inter", sans-serif; color: var(--muted); text-transform: none; letter-spacing: 0;
+  padding: 3px 10px; border-radius: 999px; border: 1px solid var(--line); background: rgba(255, 255, 255, .04); }
+.list-tools { display: flex; gap: 10px; align-items: center; }
+
+/* ---------- Buscador / chips / toggle de vista ---------- */
+.m-search { display: flex; align-items: center; gap: 8px; flex: 1; min-width: 200px;
+  background: rgba(255, 255, 255, .05); border: 1px solid var(--line); border-radius: 12px; padding: 0 12px; transition: .2s; }
+.m-search:focus-within { border-color: var(--accent); box-shadow: 0 0 0 4px rgba(110, 168, 255, .16); }
+.m-search span { color: var(--faint); font-size: 14px; }
+.m-search input { flex: 1; min-width: 0; background: transparent; border: 0; color: var(--ink); padding: 11px 0; font-size: 14px; }
+.m-search input:focus { outline: none; }
+.m-chip { cursor: pointer; white-space: nowrap; color: var(--muted); font: 600 13px "Inter", sans-serif;
+  border: 1px solid var(--line); border-radius: 12px; padding: 10px 14px; background: rgba(255, 255, 255, .04); transition: .2s; }
+.m-chip:hover { color: var(--ink); background: rgba(255, 255, 255, .08); }
+.m-chip.active { color: #0a0a0c; border-color: transparent; background: var(--foil); font-weight: 700; }
+.m-chip.danger:hover { color: var(--neg); border-color: rgba(255, 107, 107, .4); background: rgba(255, 107, 107, .1); }
+.m-views { display: inline-flex; border: 1px solid var(--line); border-radius: 12px; overflow: hidden; }
+.m-views button { width: 40px; padding: 9px 0; background: transparent; color: var(--muted); border: 0; cursor: pointer; font-size: 16px; transition: .2s; }
+.m-views button.active { background: #f5f5f7; color: #0a0a0c; }
+
+/* ---------- Galería de cartas Magic ---------- */
+.m-statbar { display: grid; grid-template-columns: repeat(auto-fit, minmax(130px, 1fr)); gap: 12px; margin-bottom: 16px; }
+.m-stat { padding: 14px 16px; border-radius: 16px; border: 1px solid var(--line);
+  background: linear-gradient(180deg, rgba(255, 255, 255, .07), rgba(255, 255, 255, .02)); backdrop-filter: blur(12px); }
+.m-stat-l { display: block; color: var(--muted); font-size: 10.5px; font-weight: 600; text-transform: uppercase; letter-spacing: .06em; }
+.m-stat-v { display: block; font-family: "Sora", sans-serif; font-weight: 800; font-size: 20px; margin-top: 4px; }
+.m-stat-s { display: block; color: var(--faint); font-size: 11.5px; margin-top: 2px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.m-toolbar { display: flex; gap: 10px; align-items: center; flex-wrap: wrap; margin-bottom: 16px; }
+.m-toolbar select { padding: 11px 12px; border-radius: 12px; }
+
+.m-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(168px, 1fr)); gap: 14px; }
+.mcard { position: relative; border-radius: 16px; overflow: hidden; border: 1px solid var(--line);
+  background: linear-gradient(180deg, rgba(255, 255, 255, .06), rgba(255, 255, 255, .02));
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, .15); transition: transform .18s, box-shadow .18s, border-color .18s;
+  display: flex; flex-direction: column; }
+.mcard:hover { transform: translateY(-4px); border-color: rgba(255, 255, 255, .28);
+  box-shadow: 0 20px 40px -20px rgba(0, 0, 0, .85); }
+.m-thumb { position: relative; aspect-ratio: 488 / 340; background: rgba(255, 255, 255, .04); overflow: hidden; }
+.m-thumb img { width: 100%; height: 100%; object-fit: cover; object-position: center 18%; display: block; }
+.m-noimg { width: 100%; height: 100%; display: grid; place-items: center; font-size: 30px; filter: grayscale(1); opacity: .5; }
+.m-qty { position: absolute; top: 8px; left: 8px; font: 700 12px "Sora", sans-serif; color: #0a0a0c;
+  background: rgba(245, 245, 247, .92); padding: 2px 9px; border-radius: 999px; backdrop-filter: blur(4px); }
+.m-foil { position: absolute; top: 8px; right: 8px; font: 700 10px "Inter", sans-serif; color: #0a0a0c;
+  background: var(--foil); padding: 3px 8px; border-radius: 999px; }
+.mcard.is-foil { border: 1.5px solid transparent; background:
+  linear-gradient(180deg, #1b1b20, #141418) padding-box,
+  var(--foil) border-box; }
+.mcard.is-foil:hover { box-shadow: 0 20px 42px -18px rgba(138, 107, 255, .5); }
+.m-info { padding: 11px 13px 13px; display: flex; flex-direction: column; gap: 6px; flex: 1; }
+.m-name { font-weight: 600; font-size: 13.5px; line-height: 1.25; overflow: hidden; text-overflow: ellipsis;
+  display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; min-height: 2.5em; }
+.m-sub { display: flex; align-items: center; gap: 7px; font-size: 11.5px; color: var(--muted); }
+.m-ed { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.m-rar { flex: none; width: 17px; height: 17px; display: grid; place-items: center; border-radius: 5px;
+  font: 700 10px "Sora", sans-serif; color: #0a0a0c; background: #b9b9bf; }
+.m-rar.r-rare { background: var(--amber); } .m-rar.r-mythic { background: #ff9d6b; }
+.m-rar.r-uncommon { background: #c9d4dc; } .m-rar.r-common { background: #8e8e93; color: #f5f5f7; }
+.m-prices { display: flex; align-items: baseline; justify-content: space-between; gap: 8px; margin-top: auto; }
+.m-unit { color: var(--muted); font-size: 12px; }
+.m-usd { color: var(--faint); font-size: 10.5px; }
+.m-val { font-family: "Sora", sans-serif; font-weight: 800; font-size: 15px; }
+
+/* Vista en lista (compacta) */
+.m-grid.is-list { grid-template-columns: 1fr; gap: 8px; }
+.m-grid.is-list .mcard { flex-direction: row; align-items: center; }
+.m-grid.is-list .m-thumb { width: 54px; aspect-ratio: auto; height: 54px; flex: none; }
+.m-grid.is-list .m-thumb img { object-position: center 22%; }
+.m-grid.is-list .m-qty, .m-grid.is-list .m-foil { display: none; }
+.m-grid.is-list .m-info { flex-direction: row; align-items: center; gap: 14px; padding: 8px 14px; width: 100%; }
+.m-grid.is-list .m-name { min-height: 0; -webkit-line-clamp: 1; flex: 1; }
+.m-grid.is-list .m-sub { flex: none; }
+.m-grid.is-list .m-prices { flex: none; gap: 16px; margin: 0; min-width: 160px; justify-content: flex-end; }
+.m-grid.is-list .mcard:hover { transform: none; }
+.m-sentinel { height: 1px; }
+.m-count { text-align: center; margin-top: 14px; }
+@media (max-width: 560px) {
+  .m-grid { grid-template-columns: repeat(auto-fill, minmax(140px, 1fr)); }
+}
+
 .status { font-size: 13px; color: var(--muted); margin: 12px 0 0; }
 .status.err { color: #d0d0d4; }
 .warn { color: var(--amber); font-size: 12.5px; margin: 8px 0 0; }

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -235,51 +235,58 @@ select:focus { outline: none; border-color: rgba(255, 255, 255, .5); }
 .m-stat-l { display: block; color: var(--muted); font-size: 10.5px; font-weight: 600; text-transform: uppercase; letter-spacing: .06em; }
 .m-stat-v { display: block; font-family: "Sora", sans-serif; font-weight: 800; font-size: 20px; margin-top: 4px; }
 .m-stat-s { display: block; color: var(--faint); font-size: 11.5px; margin-top: 2px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.m-toolbar { display: flex; gap: 10px; align-items: center; flex-wrap: wrap; margin-bottom: 16px; }
+.m-toolbar { display: flex; gap: 10px; align-items: center; flex-wrap: wrap; margin-bottom: 12px; }
 .m-toolbar select { padding: 11px 12px; border-radius: 12px; }
 
-.m-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(168px, 1fr)); gap: 14px; }
-.mcard { position: relative; border-radius: 16px; overflow: hidden; border: 1px solid var(--line);
+/* Chips de rareza (filtro) */
+.m-rars { display: flex; gap: 8px; flex-wrap: wrap; align-items: center; margin-bottom: 16px; }
+.m-rchip { cursor: pointer; color: var(--muted); font: 600 12.5px "Inter", sans-serif; padding: 7px 12px;
+  border: 1px solid var(--line); border-radius: 999px; background: rgba(255, 255, 255, .03); transition: .18s; }
+.m-rchip b { color: var(--ink); font-weight: 700; }
+.m-rchip:hover { color: var(--ink); background: rgba(255, 255, 255, .07); }
+.m-rchip::before { content: ""; display: inline-block; width: 8px; height: 8px; border-radius: 50%; margin-right: 7px; vertical-align: 1px; background: #b9b9bf; }
+.m-rchip.r-mythic::before { background: #ff9d6b; } .m-rchip.r-rare::before { background: var(--amber); }
+.m-rchip.r-uncommon::before { background: #c9d4dc; } .m-rchip.r-common::before { background: #8e8e93; }
+.m-rchip.active { color: var(--ink); border-color: rgba(255, 255, 255, .45); background: rgba(255, 255, 255, .1); }
+.m-rclear { cursor: pointer; color: var(--faint); font: 600 12px "Inter", sans-serif; background: none; border: 0; text-decoration: underline; padding: 4px; }
+
+/* Tarjetas compactas (sin imagen, para aprovechar el espacio) */
+.m-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(186px, 1fr)); gap: 12px; }
+.mcard { position: relative; border-radius: 14px; border: 1px solid var(--line); padding: 12px 14px;
   background: linear-gradient(180deg, rgba(255, 255, 255, .06), rgba(255, 255, 255, .02));
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, .15); transition: transform .18s, box-shadow .18s, border-color .18s;
-  display: flex; flex-direction: column; }
-.mcard:hover { transform: translateY(-4px); border-color: rgba(255, 255, 255, .28);
-  box-shadow: 0 20px 40px -20px rgba(0, 0, 0, .85); }
-.m-thumb { position: relative; aspect-ratio: 488 / 340; background: rgba(255, 255, 255, .04); overflow: hidden; }
-.m-thumb img { width: 100%; height: 100%; object-fit: cover; object-position: center 18%; display: block; }
-.m-noimg { width: 100%; height: 100%; display: grid; place-items: center; font-size: 30px; filter: grayscale(1); opacity: .5; }
-.m-qty { position: absolute; top: 8px; left: 8px; font: 700 12px "Sora", sans-serif; color: #0a0a0c;
-  background: rgba(245, 245, 247, .92); padding: 2px 9px; border-radius: 999px; backdrop-filter: blur(4px); }
-.m-foil { position: absolute; top: 8px; right: 8px; font: 700 10px "Inter", sans-serif; color: #0a0a0c;
-  background: var(--foil); padding: 3px 8px; border-radius: 999px; }
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, .15); transition: transform .16s, box-shadow .16s, border-color .16s;
+  display: flex; flex-direction: column; gap: 7px; }
+.mcard:hover { transform: translateY(-3px); border-color: rgba(255, 255, 255, .28);
+  box-shadow: 0 16px 34px -22px rgba(0, 0, 0, .85); }
 .mcard.is-foil { border: 1.5px solid transparent; background:
-  linear-gradient(180deg, #1b1b20, #141418) padding-box,
-  var(--foil) border-box; }
-.mcard.is-foil:hover { box-shadow: 0 20px 42px -18px rgba(138, 107, 255, .5); }
-.m-info { padding: 11px 13px 13px; display: flex; flex-direction: column; gap: 6px; flex: 1; }
-.m-name { font-weight: 600; font-size: 13.5px; line-height: 1.25; overflow: hidden; text-overflow: ellipsis;
-  display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; min-height: 2.5em; }
-.m-sub { display: flex; align-items: center; gap: 7px; font-size: 11.5px; color: var(--muted); }
-.m-ed { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  linear-gradient(180deg, #1b1b20, #141418) padding-box, var(--foil) border-box; }
+.mcard.is-foil:hover { box-shadow: 0 16px 36px -18px rgba(138, 107, 255, .5); }
+.m-head { display: flex; align-items: center; gap: 7px; }
+.m-qty { font: 700 12px "Sora", sans-serif; color: var(--accent); }
+.m-foil { margin-left: auto; font: 700 9.5px "Inter", sans-serif; color: #0a0a0c; background: var(--foil);
+  padding: 2px 8px; border-radius: 999px; letter-spacing: .02em; }
 .m-rar { flex: none; width: 17px; height: 17px; display: grid; place-items: center; border-radius: 5px;
   font: 700 10px "Sora", sans-serif; color: #0a0a0c; background: #b9b9bf; }
 .m-rar.r-rare { background: var(--amber); } .m-rar.r-mythic { background: #ff9d6b; }
 .m-rar.r-uncommon { background: #c9d4dc; } .m-rar.r-common { background: #8e8e93; color: #f5f5f7; }
-.m-prices { display: flex; align-items: baseline; justify-content: space-between; gap: 8px; margin-top: auto; }
-.m-unit { color: var(--muted); font-size: 12px; }
-.m-usd { color: var(--faint); font-size: 10.5px; }
+.m-name { font-weight: 600; font-size: 13.5px; line-height: 1.25; overflow: hidden; text-overflow: ellipsis;
+  display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; min-height: 2.4em; }
+.m-ed { font-size: 11.5px; color: var(--muted); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.m-prices { display: flex; align-items: baseline; justify-content: space-between; gap: 8px; margin-top: auto;
+  padding-top: 8px; border-top: 1px solid var(--line); }
+.m-unit { color: var(--muted); font-size: 11.5px; }
+.m-usd { color: var(--faint); font-size: 10px; }
 .m-val { font-family: "Sora", sans-serif; font-weight: 800; font-size: 15px; }
 
-/* Vista en lista (compacta) */
-.m-grid.is-list { grid-template-columns: 1fr; gap: 8px; }
-.m-grid.is-list .mcard { flex-direction: row; align-items: center; }
-.m-grid.is-list .m-thumb { width: 54px; aspect-ratio: auto; height: 54px; flex: none; }
-.m-grid.is-list .m-thumb img { object-position: center 22%; }
-.m-grid.is-list .m-qty, .m-grid.is-list .m-foil { display: none; }
-.m-grid.is-list .m-info { flex-direction: row; align-items: center; gap: 14px; padding: 8px 14px; width: 100%; }
+/* Vista en lista (una carta por fila, muy densa) */
+.m-grid.is-list { grid-template-columns: 1fr; gap: 6px; }
+.m-grid.is-list .mcard { flex-direction: row; align-items: center; gap: 14px; padding: 9px 14px; }
+.m-grid.is-list .mcard:hover { transform: none; }
+.m-grid.is-list .m-head { flex: none; }
+.m-grid.is-list .m-foil { margin-left: 0; }
 .m-grid.is-list .m-name { min-height: 0; -webkit-line-clamp: 1; flex: 1; }
-.m-grid.is-list .m-sub { flex: none; }
-.m-grid.is-list .m-prices { flex: none; gap: 16px; margin: 0; min-width: 160px; justify-content: flex-end; }
+.m-grid.is-list .m-ed { flex: none; width: 130px; text-align: right; }
+.m-grid.is-list .m-prices { flex: none; gap: 18px; margin: 0; padding: 0; border: 0; min-width: 170px; justify-content: flex-end; }
 .m-grid.is-list .mcard:hover { transform: none; }
 .m-sentinel { height: 1px; }
 .m-count { text-align: center; margin-top: 14px; }

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -4,10 +4,10 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Mi patrimonio · panel</title>
-  <meta name="description" content="Panel personal que consolida banco, Trade Republic, Nexo, skins de CS:GO y cartas Magic, con gráficos y valoración en vivo.">
+  <meta name="description" content="Panel personal que consolida banco, Trade Republic, skins de CS:GO y cartas Magic, con gráficos y valoración en vivo.">
   <meta name="theme-color" content="#060607">
   <meta property="og:title" content="Mi patrimonio">
-  <meta property="og:description" content="Todo tu patrimonio en una vista: banco, acciones, cripto, skins y cartas Magic.">
+  <meta property="og:description" content="Todo tu patrimonio en una vista: banco, acciones, skins y cartas Magic.">
   <meta property="og:type" content="website">
   <link rel="icon" type="image/svg+xml" href="{{ url_for('static', filename='favicon.svg') }}">
   <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -173,10 +173,16 @@
         <div class="row" style="margin-top:10px"><button type="button" id="importBtn">Importar a mi lista</button></div>
       </details>
 
-      <h3>Mi lista de cartas</h3>
+      <div class="list-head">
+        <h3>Mi lista de cartas <span class="count-pill" id="cardCount" hidden></span></h3>
+        <div class="list-tools" id="cardTools" hidden>
+          <div class="m-search"><span>🔎</span><input type="search" id="cardSearch" placeholder="Filtrar mi lista…" autocomplete="off"></div>
+          <button type="button" class="m-chip danger" id="cardClear">Vaciar</button>
+        </div>
+      </div>
       <div id="cardList" class="card-list"></div>
-      <div class="row" style="margin-top:12px">
-        <button type="button" id="valuarBtn">Valorar mi lista</button>
+      <div class="row" style="margin-top:14px">
+        <button type="button" id="valuarBtn">💰 Valorar mi lista</button>
       </div>
       <div id="magicResult"></div>
     </section>

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -1,0 +1,35 @@
+"""Configuración común de los tests.
+
+Antes de importar nada de la app, apunta la base de datos a un SQLite temporal
+(PATRIMONIO_DATA_DIR) y desactiva DATABASE_URL, para no tocar producción ni
+depender de PostgreSQL. También deja el directorio de la app en sys.path.
+"""
+
+import os
+import sys
+import tempfile
+
+_APP_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _APP_DIR not in sys.path:
+    sys.path.insert(0, _APP_DIR)
+
+# Base de datos aislada en un temporal (SQLite local), sin SSL ni Postgres.
+os.environ.pop("DATABASE_URL", None)
+os.environ["PATRIMONIO_DATA_DIR"] = tempfile.mkdtemp(prefix="patrimonio-tests-")
+# Sin token: que /api/monthly-summary no exija autorización en los tests.
+os.environ.pop("SUMMARY_TOKEN", None)
+
+import pytest  # noqa: E402
+
+from sources import db  # noqa: E402
+
+
+@pytest.fixture()
+def client():
+    """Cliente de pruebas de Flask con la base de datos limpia."""
+    import app as app_module
+    db.reset_snapshots()
+    app_module.app.config["TESTING"] = True
+    with app_module.app.test_client() as c:
+        yield c
+    db.reset_snapshots()

--- a/app/tests/test_api.py
+++ b/app/tests/test_api.py
@@ -1,0 +1,89 @@
+"""Rutas de la API con el cliente de pruebas de Flask (SQLite temporal)."""
+
+import app as app_module
+
+
+def test_health(client):
+    r = client.get("/health")
+    assert r.status_code == 200
+    assert r.get_json()["status"] == "ok"
+
+
+def test_version(client):
+    r = client.get("/api/version")
+    body = r.get_json()
+    assert r.status_code == 200
+    assert body["version"] == app_module.APP_VERSION
+    assert body["db"] == "sqlite"
+    assert "banco" in body["sources"]
+
+
+def test_security_headers(client):
+    r = client.get("/health")
+    assert r.headers["X-Content-Type-Options"] == "nosniff"
+    assert r.headers["X-Frame-Options"] == "SAMEORIGIN"
+
+
+def test_snapshots_vacio(client):
+    assert client.get("/api/snapshots").get_json() == {}
+
+
+def test_snapshot_invalido(client):
+    # month con formato incorrecto -> 400
+    r = client.post("/api/snapshot", json={"month": "2026/07", "category": "X", "value": 1})
+    assert r.status_code == 400
+
+
+def test_snapshot_valido_y_persistencia(client):
+    r = client.post("/api/snapshot",
+                    json={"month": "2026-07", "category": "Acciones", "value": 1000.0})
+    assert r.status_code == 200
+    snaps = client.get("/api/snapshots").get_json()
+    assert snaps["2026-07"]["Acciones"] == 1000.0
+
+
+def test_summary_endpoint(client):
+    client.post("/api/snapshot", json={"month": "2026-06", "category": "Acciones", "value": 1000.0})
+    client.post("/api/snapshot", json={"month": "2026-07", "category": "Acciones", "value": 1200.0})
+    s = client.get("/api/summary").get_json()
+    assert s["total"] == 1200.0
+    assert s["delta"] == 200.0
+
+
+def test_summary_vacio_devuelve_objeto_vacio(client):
+    assert client.get("/api/summary").get_json() == {}
+
+
+def test_monthly_summary_sin_datos(client):
+    assert client.post("/api/monthly-summary").status_code == 404
+
+
+def test_monthly_summary_envia(client, monkeypatch):
+    sent = {}
+    monkeypatch.setattr(app_module, "send_whatsapp",
+                        lambda msg: sent.update(msg=msg) or True)
+    client.post("/api/snapshot", json={"month": "2026-07", "category": "Acciones", "value": 5000.0})
+    r = client.post("/api/monthly-summary")
+    assert r.status_code == 200
+    assert r.get_json()["sent"] is True
+    assert "Acciones" in sent["msg"]
+
+
+def test_monthly_summary_token(client, monkeypatch):
+    monkeypatch.setenv("SUMMARY_TOKEN", "secreto")
+    monkeypatch.setattr(app_module, "send_whatsapp", lambda msg: True)
+    client.post("/api/snapshot", json={"month": "2026-07", "category": "Acciones", "value": 1.0})
+    assert client.post("/api/monthly-summary").status_code == 403
+    assert client.post("/api/monthly-summary?token=secreto").status_code == 200
+
+
+def test_magic_requiere_entrada(client):
+    r = client.post("/api/magic", json={})
+    assert r.status_code == 400
+
+
+def test_cards_roundtrip(client):
+    client.post("/api/cards", json={"reference": "abc", "decklist": "1 Sol Ring"})
+    body = client.get("/api/cards").get_json()
+    assert body["reference"] == "abc"
+    assert body["decklist"] == "1 Sol Ring"

--- a/app/tests/test_bank.py
+++ b/app/tests/test_bank.py
@@ -1,0 +1,66 @@
+"""Banco: categorización, gasto neto y enlace de bizums (reglas de negocio)."""
+
+from sources import bank
+
+
+def test_categorize_reglas():
+    assert bank.categorize("COMPRA MERCADONA PALMA", -42.0) == ("Supermercado", "expense")
+    assert bank.categorize("NOMINA EMPRESA SL", 1800.0) == ("Nómina", "income")
+    assert bank.categorize("TRASPASO A NEXO", -100.0) == ("Inversión (Nexo)", "investment")
+    assert bank.categorize("BIZUM RECIBIDO DE ANA", 10.0) == ("Bizum recibido", "bizum_in")
+
+
+def test_categorize_por_defecto_segun_signo():
+    assert bank.categorize("algo raro", -5.0) == ("Otros gastos", "expense")
+    assert bank.categorize("algo raro", 5.0) == ("Otros ingresos", "income")
+
+
+def _raw(*rows):
+    """rows: (concept, 'dd/mm/yyyy', amount)."""
+    return [{"concept": c, "date": d, "amount": a, "balance": 1000.0} for c, d, a in rows]
+
+
+def test_inversion_no_cuenta_como_gasto():
+    data = bank.analyze_raw(_raw(
+        ("COMPRA MERCADONA", "05/07/2026", -50.0),
+        ("TRASPASO A NEXO", "06/07/2026", -200.0),
+    ), balance=800.0)
+    agg = data["aggregates"]
+    assert agg["gastos"] == 50.0          # la inversión NO suma a gastos
+    assert agg["inversion"] == 200.0
+    assert agg["liquidez"] == 800.0
+    assert agg["month"] == "2026-07"
+
+
+def test_bizum_devolucion_reduce_gasto_neto():
+    # Cena de 30 € con un bizum de 10 € el mismo día -> gasto neto 20 €.
+    data = bank.analyze_raw(_raw(
+        ("RESTAURANTE LA CENA", "10/07/2026", -30.0),
+        ("BIZUM RECIBIDO DE LUIS", "10/07/2026", 10.0),
+    ), balance=500.0)
+    bizum = next(t for t in data["transactions"] if t["kind"] == "bizum_in")
+    assert bizum["suggested_link"] is not None      # se liga a la cena
+    assert data["aggregates"]["gastos"] == 20.0     # 30 - 10
+
+
+def test_bizum_recurrente_se_marca_como_ingreso():
+    # Tres bizums del mismo importe -> ingreso recurrente, no devolución.
+    rows = _raw(
+        ("RESTAURANTE", "01/07/2026", -100.0),
+        ("BIZUM RECIBIDO ALQUILER", "02/07/2026", 25.0),
+        ("BIZUM RECIBIDO ALQUILER", "12/07/2026", 25.0),
+        ("BIZUM RECIBIDO ALQUILER", "22/07/2026", 25.0),
+    )
+    data = bank.analyze_raw(rows, balance=None)
+    bizums = [t for t in data["transactions"] if t["kind"] == "bizum_in"]
+    assert all(b["recurring_income"] for b in bizums)
+    assert all(b["suggested_link"] is None for b in bizums)
+    # 3 × 25 € entran como ingreso; el gasto bruto (100) no se reduce.
+    assert data["aggregates"]["ganancias"] == 75.0
+    assert data["aggregates"]["gastos"] == 100.0
+
+
+def test_aggregates_sin_movimientos():
+    data = bank.analyze_raw([], balance=None)
+    assert data["month"] is None
+    assert data["aggregates"]["gastos"] == 0.0

--- a/app/tests/test_common.py
+++ b/app/tests/test_common.py
@@ -1,0 +1,36 @@
+"""Utilidades compartidas: parseo de importes y extracción de mes."""
+
+from sources.common import parse_money, to_month
+
+
+def test_parse_money_europeo():
+    assert parse_money("1.234,56 €") == 1234.56
+    assert parse_money("0,99") == 0.99
+    assert parse_money("-45,00€") == -45.0
+
+
+def test_parse_money_americano():
+    assert parse_money("1,234.56") == 1234.56
+    assert parse_money("$1,000.00") == 1000.0
+
+
+def test_parse_money_solo_coma_miles_vs_decimal():
+    # Con coma como separador de miles (sin decimales) -> entero.
+    assert parse_money("1,000") == 1000.0
+    assert parse_money("12,50") == 12.5            # coma decimal
+
+
+def test_parse_money_parentesis_negativo():
+    assert parse_money("(30,00)") == -30.0
+
+
+def test_parse_money_invalido():
+    assert parse_money("") is None
+    assert parse_money(None) is None
+    assert parse_money("n/a") is None
+
+
+def test_to_month():
+    assert to_month("Movimiento del 05/07/2026") == "2026-07"
+    assert to_month("fecha 31.12.2025 ref") == "2025-12"
+    assert to_month("sin fecha") is None

--- a/app/tests/test_patrimonio.py
+++ b/app/tests/test_patrimonio.py
@@ -1,0 +1,68 @@
+"""Dominio del patrimonio: resumen mensual, formato y mensaje de WhatsApp."""
+
+from sources import patrimonio
+
+
+def test_is_flow():
+    assert patrimonio.is_flow("_flow:gastos")
+    assert not patrimonio.is_flow("Acciones / ETFs")
+
+
+def test_month_total_excluye_flujos():
+    snap = {"Acciones": 1000.0, "Liquidez (banco)": 500.0,
+            "_flow:gastos": 200.0, "_flow:ganancias": 1800.0}
+    assert patrimonio.month_total(snap) == 1500.0
+
+
+def test_summary_vacio():
+    assert patrimonio.summary({}) is None
+    assert patrimonio.summary(None) is None
+
+
+def test_summary_un_solo_mes():
+    s = patrimonio.summary({"2026-07": {"Acciones": 1000.0, "_flow:gastos": 100.0}})
+    assert s["month"] == "2026-07"
+    assert s["total"] == 1000.0
+    assert s["prev"] is None
+    assert s["delta"] is None
+    assert s["pct"] is None
+    assert s["gastos"] == 100.0
+    assert s["categories"] == {"Acciones": 1000.0}
+
+
+def test_summary_variacion_entre_meses():
+    snaps = {
+        "2026-06": {"Acciones": 1000.0},
+        "2026-07": {"Acciones": 1100.0, "Liquidez": 400.0,
+                    "_flow:gastos": 300.0, "_flow:ganancias": 1800.0},
+    }
+    s = patrimonio.summary(snaps)
+    assert s["total"] == 1500.0
+    assert s["prev"] == 1000.0
+    assert s["delta"] == 500.0
+    assert s["pct"] == 50.0
+    assert s["ganancias"] == 1800.0
+
+
+def test_eur_formato_espanol():
+    assert patrimonio.eur(1234.56) == "1.234,56 €"
+    assert patrimonio.eur(0) == "0,00 €"
+    assert patrimonio.eur(1000000) == "1.000.000,00 €"
+
+
+def test_whatsapp_message_incluye_total_y_flecha():
+    snaps = {
+        "2026-06": {"Acciones": 1000.0},
+        "2026-07": {"Acciones": 1500.0, "_flow:gastos": 200.0, "_flow:ganancias": 1800.0},
+    }
+    msg = patrimonio.whatsapp_message(patrimonio.summary(snaps))
+    assert "Tu patrimonio" in msg
+    assert "1.500,00 €" in msg
+    assert "📈" in msg                 # subió
+    assert "Acciones" in msg
+
+
+def test_whatsapp_message_baja():
+    snaps = {"2026-06": {"Acciones": 1000.0}, "2026-07": {"Acciones": 800.0}}
+    msg = patrimonio.whatsapp_message(patrimonio.summary(snaps))
+    assert "📉" in msg

--- a/app/tests/test_trade_republic.py
+++ b/app/tests/test_trade_republic.py
@@ -1,0 +1,35 @@
+"""Trade Republic: parseo del CSV normalizado (cabeceras, delimitadores)."""
+
+from sources import trade_republic as tr
+
+
+def test_parse_csv_normalizado():
+    text = ("name,isin,quantity,price,value\n"
+            "Apple,US0378331005,3,180.50,541.50\n"
+            "Vanguard FTSE All-World,IE00BK5BQT80,12,118.20,1418.40\n")
+    positions, warnings = tr._parse_csv(text)
+    assert len(positions) == 2
+    assert positions[0].name == "Apple"
+    assert positions[0].value == 541.50
+    assert round(sum(p.value for p in positions), 2) == 1959.90
+
+
+def test_parse_csv_delimitador_punto_y_coma_y_cabeceras_es():
+    text = ("nombre;isin;cantidad;precio;valor\n"
+            "Iberdrola;ES0144580Y14;100;11,50;1.150,00\n")
+    positions, warnings = tr._parse_csv(text)
+    assert len(positions) == 1
+    assert positions[0].name == "Iberdrola"
+    assert positions[0].value == 1150.0
+
+
+def test_parse_csv_calcula_valor_desde_precio():
+    text = "name,quantity,price\nTest,2,10.00\n"
+    positions, _ = tr._parse_csv(text)
+    assert positions[0].value == 20.0
+
+
+def test_parse_csv_cabeceras_no_reconocidas():
+    positions, warnings = tr._parse_csv("foo,bar\n1,2\n")
+    assert positions == []
+    assert warnings


### PR DESCRIPTION
Revisión E2E del código como arquitecto, refactor para profesionalizar la app y **rediseño completo de la vista de cartas Magic**. Sin cambios de comportamiento en lo existente (verificado con tests).

## 🃏 Cartas Magic — galería moderna (nuevo)
Pensada para una colección potencialmente enorme, **sin paginación** pero con UX profesional:
- **Backend (`moxfield`)**: Scryfall ahora aporta miniatura, rareza, tipo y nombre de edición por carta (soporta cartas de doble cara vía `card_faces`).
- **Galería rica** (`renderMagic`): tiles con arte, badges de **rareza/cantidad/foil**, precio unidad + total y barra de **estadísticas** (cartas, valor total, más cara, foils).
- **Buscador instantáneo** (nombre/set/tipo), **orden** (valor · precio ud. · cantidad · nombre), filtro **solo foil** y conmutador **cuadrícula/lista**.
- **Sin paginación**: renderizado **progresivo por bloques** con `IntersectionObserver` + imágenes **perezosas** → el DOM no crece de golpe aunque la lista sea casi infinita.
- **Gestor de cartas**: buscador, contador (líneas/cartas), botón *vaciar* y borrado por **delegación** (robusto con miles de filas).

## 🏗️ Arquitectura (dominio vs. web)
- Nuevo `sources/patrimonio.py`: lógica de negocio (resumen mensual, variación, formato `€`, mensaje de WhatsApp) separada de la capa web.
- `app.py` reescrito (`r13`): imports al inicio, sin código muerto, decorador `api_error` (JSON `{error}` con código correcto), helper `_process_upload`, delegación al módulo de dominio.

## 🔒 Endurecimiento
- Cabeceras de seguridad (`X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`).
- **XSS**: `esc()` en `app.js` escapando todo lo inyectado en `innerHTML` (cartas, items de Steam, conceptos del banco, categorías). `_twiml` escapa el XML.

## ✅ Calidad / tests
- **37 tests con pytest** (verdes): `common`, banco (gasto neto/bizums/inversión), dominio patrimonio, Trade Republic CSV y rutas de la API (cliente Flask + SQLite).
- `requirements-dev.txt`, `pytest.ini`, workflow de CI **`tests.yml`** y `.gitignore`.

## 🧹 Limpieza
- Quitadas referencias obsoletas a Nexo/cripto en meta/OpenGraph.

> Nota: la rama original asignada (`claude/expense-table-categories-tokrp6`, PR #3 ya fusionada) había divergido; este trabajo va en rama limpia hacia `master`, como el resto de PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013GLk7agL8h761C1CYpmCGu