### PR TITLE
WhatsApp semanal: disparo manual envía siempre (prueba)

### DIFF
--- a/.github/workflows/weekly-whatsapp.yml
+++ b/.github/workflows/weekly-whatsapp.yml
@@ -14,6 +14,8 @@ jobs:
       CALLMEBOT_APIKEY: ${{ secrets.CALLMEBOT_APIKEY }}
       CALLMEBOT_PHONE: ${{ secrets.CALLMEBOT_PHONE || '34640253466' }}
       ALERT_THRESHOLD: "10"
+      # En un disparo manual (prueba) envía siempre, aunque no haya subidas.
+      ALERT_SEND_EMPTY: ${{ github.event_name == 'workflow_dispatch' && '1' || '0' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5


### PR DESCRIPTION
## Qué

Permite probar el envío del resumen semanal por WhatsApp de punta a punta: en un **disparo manual** (`workflow_dispatch`) se fija `ALERT_SEND_EMPTY=1`, de modo que el mensaje se envía **aunque no haya subidas >10%**.

El cron semanal automático sigue igual (no envía si no hay nada, para no meter ruido).

## Por qué

El resumen semanal es un workflow de GitHub Actions, no un endpoint. Con el histórico de precios recién purgado no hay subidas que reportar, así que un run manual no enviaba nada. Este cambio hace que el botón *Run workflow* mande un WhatsApp de prueba real (con la clave real de CallMeBot) confirmando que el canal funciona.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013GLk7agL8h761C1CYpmCGu

---
_Generated by [Claude Code](https://claude.ai/code/session_013GLk7agL8h761C1CYpmCGu)_