### PR TITLE
Resumen semanal: revalorizar skins y cartas en vivo + estudio API imagin/Trade Republic

### DIFF
--- a/app/BANCOS_API.md
+++ b/app/BANCOS_API.md
@@ -1,0 +1,111 @@
+# Estudio: conectar imagin (CaixaBank) y Trade Republic por API
+
+Objetivo: que «Liquidez (banco)» y «Acciones / ETFs» se actualicen solas cada
+semana, igual que ya hacen skins y cartas, sin subir PDFs a mano. Este
+documento recoge las vías REALES disponibles a fecha 2026-07, con sus
+requisitos y riesgos. Nada de lo de abajo está inventado: cada opción enlaza a
+su documentación.
+
+---
+
+## 1. imagin (CaixaBank)
+
+imagin no tiene API pública propia para particulares: es una marca de
+CaixaBank y su acceso programático pasa por PSD2 (open banking). Tres vías:
+
+### 1a. PSD2 directo (hub Redsys) — descartado
+CaixaBank/imagin exponen su API XS2A en el hub de Redsys
+(<https://market.apis-i.redsys.es/psd2/xs2a/nodos/caixabank>). Solo pueden
+usarla TPPs con licencia AISP del Banco de España y certificado eIDAS.
+Inviable para uso personal.
+
+### 1b. Enable Banking — RECOMENDADA
+<https://enablebanking.com/docs/> · cobertura ES: imagin y CaixaBank aparecen
+como ASPSPs integrados (AIS en sandbox y producción; imagin migró en 2025 a
+APIs específicas para clientes de la app imagin).
+
+Por qué encaja aquí:
+* **Alta self-service** y modo «restricted production»: gratis para acceder a
+  TUS PROPIAS cuentas (el backend solo devuelve las cuentas vinculadas a la
+  aplicación). Es exactamente el caso de este proyecto.
+* API REST con JWT (firmas con clave privada propia); endpoints de sesiones,
+  `accounts`, `balances` y `transactions`.
+* SCA: la autorización se hace en la app de imagin (DNI/NIE + PIN/biometría).
+  El consentimiento PSD2 caduca (90/180 días según banco) y hay que renovarlo
+  repitiendo la autorización — es una limitación regulatoria, no del agregador.
+
+Plan de integración (siguiente PR):
+1. Registrar app en Enable Banking (modo restricted production) y guardar
+   `EB_APP_ID` + clave privada como secretos del servidor.
+2. Nuevo `sources/enablebanking.py`: crear sesión → listar cuentas → traer
+   `balances` y `transactions`, mapear al formato de `bank.analyze_raw()`
+   (igual que hace `wealthreader.py`) y persistir con
+   `ingest.persist_bank_aggregates()`.
+3. Añadir «Liquidez (banco)» a la revalorización semanal (`sources/revalue.py`).
+   Si el consentimiento ha caducado, el resumen de WhatsApp lo dirá en un
+   aviso ⚠️ (fallo visible, sin arrastrar el saldo viejo en silencio) y la web
+   ofrecerá el botón de renovar.
+
+### 1c. Wealth Reader — ya integrada, requiere API key comercial
+El repo ya tiene `sources/wealthreader.py` y `POST /api/wealthreader`
+(<https://www.wealthreader.com/api-reference/es/>). Soporta `caixabank`; si
+imagin aparece como entidad separada se comprueba en su endpoint
+`GET /entities/`. Pega: la API key es de contratación comercial (no hay tier
+gratuito personal publicado). Mantenerla como vía alternativa si ya se dispone
+de key.
+
+### Descartada: GoCardless Bank Account Data (ex-Nordigen)
+Era la opción gratuita clásica, pero desde mediados de 2025 **no acepta altas
+nuevas** y está en proceso de cierre. No empezar nada nuevo sobre ella.
+
+---
+
+## 2. Trade Republic
+
+**No existe API oficial pública.** La app habla con
+`api.traderepublic.com` por websocket y la comunidad lo ha documentado:
+
+### 2a. pytr (cliente no oficial) — la vía práctica
+<https://github.com/pytr-org/pytr> (PyPI: `pytr`).
+* Login con teléfono + PIN; el primer login hace «device pairing» (genera un
+  keypair local que queda como dispositivo autorizado) y después ya no pide
+  SMS en cada ejecución.
+* Da lo que necesitamos: `portfolio()` (posiciones con valor actual),
+  `cash()`, histórico y descarga de documentos.
+* Riesgos reales: es ingeniería inversa (puede romperse con cualquier cambio
+  de TR y va contra sus condiciones de uso → en el peor caso, bloqueo de la
+  cuenta); desde mediados de 2026 TR añadió un token AWS WAF al login y el
+  bypass de pytr sufre rate-limiting. Alternativas de la comunidad:
+  `tr-api` (<https://github.com/cdamken/tr-api>, login con Playwright o
+  importación de cookies) y `pytrpp` para exportar movimientos.
+
+Plan de integración (siguiente PR):
+1. `sources/trade_republic_live.py` con `pytr`: login con credenciales en
+   variables de entorno (`TR_PHONE`, `TR_PIN`) y el fichero de pairing en el
+   disco persistente del servidor; suscripción a `portfolio` + `cash` y suma
+   en EUR.
+2. Guardar snapshot «Acciones / ETFs» del mes en curso y engancharlo a
+   `revalue.refresh_live()` como tercera categoría.
+3. Si el login caduca o TR rompe el protocolo: error visible en el WhatsApp
+   semanal, y siempre queda la ingesta actual por PDF/CSV
+   (`sources/trade_republic.py`), que sigue siendo el camino manual soportado.
+
+### 2b. Mantener PDF/CSV (estado actual)
+Cero riesgo y ya funciona, pero exige subir el extracto a mano: es
+exactamente lo que hace que el mensaje semanal repita el mismo importe. Se
+mantiene como camino manual, no como sustituto de 2a.
+
+---
+
+## Resumen y orden propuesto
+
+| Fuente | Vía | Coste | Riesgo | Estado |
+|---|---|---|---|---|
+| imagin | Enable Banking (restricted prod) | 0 € (cuentas propias) | Bajo (agregador regulado; renovar consentimiento cada 90/180 días) | Propuesto |
+| imagin | Wealth Reader | API key comercial | Bajo | Integrado, sin key |
+| Trade Republic | pytr / tr-api (websocket no oficial) | 0 € | Medio-alto (no oficial, ToS, WAF) | Propuesto |
+| Trade Republic | PDF/CSV manual | 0 € | Ninguno | Funciona hoy |
+
+Orden sugerido: primero Enable Banking (estable y regulado), después
+Trade Republic con `pytr` asumiendo su fragilidad (con fallo visible cuando se
+rompa, nunca datos antiguos disfrazados de nuevos).

--- a/app/app.py
+++ b/app/app.py
@@ -35,10 +35,10 @@ from xml.sax.saxutils import escape as xml_escape
 from flask import Flask, jsonify, render_template, request
 
 from sources import (bank, trade_republic, steam, moxfield, db, ingest,
-                     wealthreader, patrimonio)
+                     wealthreader, patrimonio, revalue)
 from jobs.weekly_whatsapp import send_whatsapp
 
-APP_VERSION = "2026-06-r13-refactor"
+APP_VERSION = "2026-07-r14-revalue"
 MONTH_RE = re.compile(r"^\d{4}-\d{2}$")
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
@@ -188,15 +188,25 @@ def api_summary():
 
 @app.route("/api/monthly-summary", methods=["GET", "POST"])
 def api_monthly_summary():
-    """Envía por WhatsApp el patrimonio y su variación (cron semanal)."""
+    """Envía por WhatsApp el patrimonio y su variación (cron semanal).
+
+    Antes de componer el mensaje revaloriza EN VIVO las skins (Steam Market) y
+    las cartas (Scryfall) con la configuración guardada, para que esas cifras
+    cambien cada semana sin abrir la web. Si una fuente configurada falla, el
+    error va en el propio mensaje (nunca se disfraza con el valor antiguo).
+    """
     expected = os.environ.get("SUMMARY_TOKEN", "").strip()
     if expected and request.args.get("token", "") != expected:
         return jsonify({"error": "No autorizado."}), 403
+    refreshed, refresh_errors = revalue.refresh_live()
     s = patrimonio.summary(db.get_snapshots())
     if not s:
-        return jsonify({"error": "Sin datos."}), 404
-    sent = send_whatsapp(patrimonio.whatsapp_message(s))
-    return jsonify({"sent": bool(sent), "summary": s})
+        return jsonify({"error": "Sin datos.", "refresh_errors": refresh_errors}), 404
+    warnings = [f"{cat} no se pudo revalorizar: {err}"
+                for cat, err in refresh_errors.items()]
+    sent = send_whatsapp(patrimonio.whatsapp_message(s, warnings=warnings))
+    return jsonify({"sent": bool(sent), "summary": s, "refreshed": refreshed,
+                    "refresh_errors": refresh_errors})
 
 
 # ---------------------------------------------------------------------------

--- a/app/sources/patrimonio.py
+++ b/app/sources/patrimonio.py
@@ -18,24 +18,43 @@ def month_total(month_snapshot):
     return round(sum(v for k, v in month_snapshot.items() if not is_flow(k)), 2)
 
 
+def latest_categories(snapshots):
+    """Último valor conocido de cada categoría: { cat: (valor, mes de origen) }.
+
+    Cada fuente se actualiza a su ritmo (skins/cartas en vivo, banco/TR al subir
+    el extracto); el patrimonio actual es el dato más reciente de cada una.
+    """
+    view = {}
+    for month in sorted(snapshots or {}):
+        for k, v in snapshots[month].items():
+            if not is_flow(k):
+                view[k] = (v, month)
+    return view
+
+
 def summary(snapshots):
-    """Resumen del último mes: total, total previo, variación y flujos.
+    """Resumen actual: total (último valor de cada categoría), variación y flujos.
 
     snapshots: { 'YYYY-MM': { categoria|_flow:x : valor } }. None si no hay datos.
+    Las categorías sin dato del último mes conservan su valor previo, y su mes de
+    origen queda en 'category_months' para poder señalarlas como antiguas.
     """
     months = sorted(snapshots or {})
     if not months:
         return None
     last = months[-1]
-    cur = month_total(snapshots[last])
-    prev = month_total(snapshots[months[-2]]) if len(months) > 1 else None
+    view = latest_categories(snapshots)
+    cur = round(sum(v for v, _ in view.values()), 2)
+    prev_view = latest_categories({m: snapshots[m] for m in months[:-1]})
+    prev = round(sum(v for v, _ in prev_view.values()), 2) if prev_view else None
     delta = round(cur - prev, 2) if prev is not None else None
     pct = round((cur - prev) / prev * 100, 1) if prev else None
     flows = snapshots[last]
     return {
         "month": last, "total": cur, "prev": prev, "delta": delta, "pct": pct,
         "gastos": flows.get("_flow:gastos"), "ganancias": flows.get("_flow:ganancias"),
-        "categories": {k: v for k, v in flows.items() if not is_flow(k)},
+        "categories": {k: v for k, (v, _) in view.items()},
+        "category_months": {k: m for k, (_, m) in view.items()},
     }
 
 
@@ -44,16 +63,26 @@ def eur(n):
     return f"{n:,.2f} €".replace(",", "\x00").replace(".", ",").replace("\x00", ".")
 
 
-def whatsapp_message(s):
-    """Construye el mensaje de WhatsApp del resumen de patrimonio."""
+def whatsapp_message(s, warnings=None):
+    """Construye el mensaje de WhatsApp del resumen de patrimonio.
+
+    Las categorías cuyo dato no es del mes en curso se marcan con su mes de
+    origen, y los avisos (p. ej. una fuente que falló al revalorizar) se añaden
+    al final: mejor un fallo visible que un número que parece fresco sin serlo.
+    """
     lines = [f"💼 *Tu patrimonio* ({s['month']})", "", f"Total: *{eur(s['total'])}*"]
     if s["pct"] is not None:
         arrow = "📈" if s["delta"] >= 0 else "📉"
         sign = "+" if s["delta"] >= 0 else ""
         lines.append(f"{arrow} {sign}{eur(s['delta'])} ({s['pct']:+.1f}%) vs periodo anterior")
+    cat_months = s.get("category_months") or {}
     for k, v in sorted(s["categories"].items(), key=lambda x: -x[1]):
-        lines.append(f"• {k}: {eur(v)}")
+        m = cat_months.get(k)
+        stale = f" (de {m})" if m and m != s["month"] else ""
+        lines.append(f"• {k}: {eur(v)}{stale}")
     if s.get("ganancias") is not None:
         lines.append(f"\n🟢 Ingresos: {eur(s['ganancias'])}   🔴 Gastos: {eur(s.get('gastos') or 0)}")
+    for w in warnings or []:
+        lines.append(f"\n⚠️ {w}")
     lines.append("\nMi patrimonio · resumen automático")
     return "\n".join(lines)

--- a/app/sources/revalue.py
+++ b/app/sources/revalue.py
@@ -1,0 +1,91 @@
+"""
+Revalorización en vivo, en el servidor, de skins CS:GO y cartas Magic.
+
+El resumen semanal (POST /api/monthly-summary) la usa para que esas categorías
+se actualicen aunque nadie abra la web: lee la configuración que ya está
+guardada (SteamID64 y lista de Magic), pide los precios REALES a Steam Market
+y Scryfall y guarda el snapshot del mes actual.
+
+Reglas:
+  * Fuente sin configurar -> NotConfigured (se omite, no es un error).
+  * Fuente configurada que falla -> la excepción llega al llamador para que el
+    fallo sea VISIBLE (nada de valores antiguos disfrazados de nuevos).
+  * Si Steam corta por rate-limit (429) el total sería parcial: se descarta y
+    se reporta el error en vez de guardar un valor incompleto.
+"""
+
+import datetime
+import json
+import os
+
+from . import steam, moxfield, db
+
+_HERE = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+class NotConfigured(RuntimeError):
+    """La fuente no está configurada: se omite sin considerarlo un fallo."""
+
+
+def _config_steamid():
+    try:
+        with open(os.path.join(_HERE, "config.json")) as fh:
+            cfg = json.load(fh)
+    except (OSError, ValueError):
+        return ""
+    return str((cfg.get("steam") or {}).get("steamid64", "")).strip()
+
+
+def _steamid():
+    """SteamID64 real: entorno > setting guardado por la web > config.json."""
+    for sid in (os.environ.get("STEAM_ID64", "").strip(),
+                str(db.get_setting("steam_id64", "") or "").strip(),
+                _config_steamid()):
+        if sid and not sid.startswith("TU_"):
+            return sid
+    return ""
+
+
+def refresh_skins(month):
+    """Valora el inventario de Steam en vivo y guarda el snapshot del mes."""
+    sid = _steamid()
+    if not sid:
+        raise NotConfigured("Sin SteamID64 guardado (ábrelo una vez en la web "
+                            "o define STEAM_ID64).")
+    r = steam.analyze(sid)
+    partial = [w for w in r.get("warnings", []) if "429" in w]
+    if partial:
+        raise RuntimeError(partial[0])
+    db.set_snapshot(month, r["category"], r["total"])
+    return r["total"]
+
+
+def refresh_cards(month):
+    """Valora la lista de Magic guardada en vivo y guarda el snapshot del mes."""
+    saved = db.get_setting("magic_cards", {}) or {}
+    reference = (saved.get("reference") or "").strip()
+    decklist = saved.get("decklist") or ""
+    if not reference and not decklist.strip():
+        raise NotConfigured("Sin lista de Magic guardada (guárdala una vez en la web).")
+    r = moxfield.analyze(reference=reference or None, decklist=decklist)
+    db.set_snapshot(month, r["category"], r["total"])
+    return r["total"]
+
+
+def refresh_live(month=None):
+    """Revaloriza skins y cartas para `month` (por defecto, el mes actual).
+
+    Devuelve (results, errors): results[categoría] = total guardado y
+    errors[categoría] = mensaje del fallo. Lo no configurado no aparece.
+    """
+    month = month or datetime.date.today().strftime("%Y-%m")
+    results, errors = {}, {}
+    for category, fn in (("Skins CS:GO", refresh_skins),
+                         ("Cartas Magic", refresh_cards)):
+        try:
+            results[category] = fn(month)
+        except NotConfigured:
+            continue
+        except Exception as exc:  # noqa: BLE001
+            errors[category] = str(exc)
+    return results, errors

--- a/app/static/app.js
+++ b/app/static/app.js
@@ -706,18 +706,26 @@ fetch("/api/config").then((r) => r.json()).then((c) => {
 fetch("/api/snapshots").then((r) => r.json()).then((snaps) => {
   const months = Object.keys(snaps || {}).sort();
   if (!months.length) return;
-  // Variación mensual: total (sin flujos) del mes anterior.
+  // Última valoración conocida de cada categoría: cada fuente se actualiza a su
+  // ritmo (skins/cartas en vivo, banco/TR al subir extracto) y no debe
+  // desaparecer del total solo porque aún no tenga dato del mes en curso.
+  const latest = (upto) => {
+    const view = {};
+    for (const m of months.slice(0, upto)) {
+      for (const [k, v] of Object.entries(snaps[m])) {
+        if (!k.startsWith("_flow:")) view[k] = v;
+      }
+    }
+    return view;
+  };
+  // Variación: total con los últimos valores conocidos hasta el mes anterior.
   if (months.length > 1) {
-    const pm = snaps[months[months.length - 2]];
-    EVOL.prev = Object.entries(pm).reduce((s, [k, v]) => s + (k.startsWith("_flow:") ? 0 : v), 0);
+    EVOL.prev = Object.values(latest(months.length - 1)).reduce((s, v) => s + v, 0);
   }
-  const last = snaps[months[months.length - 1]];      // mes más reciente
-  for (const [k, v] of Object.entries(last)) {
-    if (k === "_flow:gastos") FLOWS.gastos = v;
-    else if (k === "_flow:ganancias") FLOWS.ganancias = v;
-    else if (k.startsWith("_flow:")) { /* inversión u otros: no se muestran como patrimonio */ }
-    else CONTRIB[k] = v;                              // categoría de patrimonio
-  }
+  Object.assign(CONTRIB, latest(months.length));
+  const last = snaps[months[months.length - 1]];      // flujos: solo del mes más reciente
+  if ("_flow:gastos" in last) FLOWS.gastos = last["_flow:gastos"];
+  if ("_flow:ganancias" in last) FLOWS.ganancias = last["_flow:ganancias"];
   renderSummary();
   if (window.Charts) window.Charts.refreshPie(CONTRIB);
   const hint = document.getElementById("summaryHint");

--- a/app/tests/test_api.py
+++ b/app/tests/test_api.py
@@ -77,6 +77,31 @@ def test_monthly_summary_token(client, monkeypatch):
     assert client.post("/api/monthly-summary?token=secreto").status_code == 200
 
 
+def test_monthly_summary_revaloriza_skins_y_cartas(client, monkeypatch):
+    sent = {}
+    monkeypatch.setattr(app_module, "send_whatsapp",
+                        lambda msg: sent.update(msg=msg) or True)
+    monkeypatch.setattr(app_module.revalue, "refresh_live",
+                        lambda: ({"Skins CS:GO": 150.0}, {}))
+    client.post("/api/snapshot", json={"month": "2026-07", "category": "Acciones", "value": 5000.0})
+    body = client.post("/api/monthly-summary").get_json()
+    assert body["refreshed"] == {"Skins CS:GO": 150.0}
+    assert body["refresh_errors"] == {}
+
+
+def test_monthly_summary_avisa_si_una_fuente_falla(client, monkeypatch):
+    sent = {}
+    monkeypatch.setattr(app_module, "send_whatsapp",
+                        lambda msg: sent.update(msg=msg) or True)
+    monkeypatch.setattr(app_module.revalue, "refresh_live",
+                        lambda: ({}, {"Skins CS:GO": "Steam no deja leer el inventario."}))
+    client.post("/api/snapshot", json={"month": "2026-07", "category": "Acciones", "value": 5000.0})
+    r = client.post("/api/monthly-summary")
+    assert r.status_code == 200
+    assert "⚠️ Skins CS:GO no se pudo revalorizar" in sent["msg"]
+    assert "Steam no deja leer el inventario." in sent["msg"]
+
+
 def test_magic_requiere_entrada(client):
     r = client.post("/api/magic", json={})
     assert r.status_code == 400

--- a/app/tests/test_patrimonio.py
+++ b/app/tests/test_patrimonio.py
@@ -44,6 +44,39 @@ def test_summary_variacion_entre_meses():
     assert s["ganancias"] == 1800.0
 
 
+def test_summary_arrastra_ultimo_valor_de_cada_categoria():
+    # El banco no tiene dato de julio: se usa su último valor (junio) y se
+    # recuerda de qué mes viene, en vez de hacer desaparecer la categoría.
+    snaps = {
+        "2026-06": {"Liquidez (banco)": 500.0, "Skins CS:GO": 100.0},
+        "2026-07": {"Skins CS:GO": 120.0},
+    }
+    s = patrimonio.summary(snaps)
+    assert s["total"] == 620.0
+    assert s["categories"] == {"Liquidez (banco)": 500.0, "Skins CS:GO": 120.0}
+    assert s["category_months"] == {"Liquidez (banco)": "2026-06",
+                                    "Skins CS:GO": "2026-07"}
+    assert s["prev"] == 600.0
+    assert s["delta"] == 20.0
+
+
+def test_whatsapp_message_marca_datos_antiguos():
+    snaps = {
+        "2026-06": {"Liquidez (banco)": 500.0},
+        "2026-07": {"Skins CS:GO": 120.0},
+    }
+    msg = patrimonio.whatsapp_message(patrimonio.summary(snaps))
+    assert "Liquidez (banco): 500,00 € (de 2026-06)" in msg
+    assert "Skins CS:GO: 120,00 €\n" in msg     # dato fresco, sin marca
+
+
+def test_whatsapp_message_incluye_avisos():
+    snaps = {"2026-07": {"Skins CS:GO": 120.0}}
+    msg = patrimonio.whatsapp_message(patrimonio.summary(snaps),
+                                      warnings=["Cartas Magic no se pudo revalorizar: Moxfield caído"])
+    assert "⚠️ Cartas Magic no se pudo revalorizar: Moxfield caído" in msg
+
+
 def test_eur_formato_espanol():
     assert patrimonio.eur(1234.56) == "1.234,56 €"
     assert patrimonio.eur(0) == "0,00 €"

--- a/app/tests/test_revalue.py
+++ b/app/tests/test_revalue.py
@@ -1,0 +1,82 @@
+"""Revalorización en vivo de skins/cartas: guarda el snapshot del mes actual."""
+
+import datetime
+
+import pytest
+
+from sources import db, revalue
+
+MONTH = datetime.date.today().strftime("%Y-%m")
+
+
+@pytest.fixture(autouse=True)
+def _aislado(monkeypatch):
+    """Sin STEAM_ID64 del entorno y con los snapshots limpios en cada test."""
+    monkeypatch.delenv("STEAM_ID64", raising=False)
+    db.reset_snapshots()
+    yield
+    db.reset_snapshots()
+
+
+def _settings(monkeypatch, values):
+    monkeypatch.setattr(revalue.db, "get_setting",
+                        lambda key, default=None: values.get(key, default))
+
+
+def test_sin_configurar_no_registra_nada(monkeypatch):
+    _settings(monkeypatch, {})
+    results, errors = revalue.refresh_live()
+    assert results == {}
+    assert errors == {}
+    assert db.get_snapshots() == {}
+
+
+def test_refresh_skins_guarda_snapshot(monkeypatch):
+    _settings(monkeypatch, {"steam_id64": "76561198000000000"})
+    monkeypatch.setattr(revalue.steam, "analyze", lambda sid: {
+        "category": "Skins CS:GO", "total": 123.45, "warnings": []})
+    results, errors = revalue.refresh_live()
+    assert results["Skins CS:GO"] == 123.45
+    assert errors == {}
+    assert db.get_snapshots()[MONTH]["Skins CS:GO"] == 123.45
+
+
+def test_refresh_skins_descarta_total_parcial_por_429(monkeypatch):
+    _settings(monkeypatch, {"steam_id64": "76561198000000000"})
+    monkeypatch.setattr(revalue.steam, "analyze", lambda sid: {
+        "category": "Skins CS:GO", "total": 10.0,
+        "warnings": ["Steam Market limitó las peticiones (429); precios parciales."]})
+    results, errors = revalue.refresh_live()
+    assert "Skins CS:GO" not in results
+    assert "429" in errors["Skins CS:GO"]
+    assert db.get_snapshots() == {}
+
+
+def test_refresh_cards_guarda_snapshot(monkeypatch):
+    _settings(monkeypatch, {"magic_cards": {"reference": "", "decklist": "1 Sol Ring"}})
+    seen = {}
+    monkeypatch.setattr(revalue.moxfield, "analyze",
+                        lambda reference=None, decklist=None:
+                        seen.update(decklist=decklist)
+                        or {"category": "Cartas Magic", "total": 9.99})
+    results, errors = revalue.refresh_live()
+    assert results["Cartas Magic"] == 9.99
+    assert errors == {}
+    assert seen["decklist"] == "1 Sol Ring"
+    assert db.get_snapshots()[MONTH]["Cartas Magic"] == 9.99
+
+
+def test_fallo_de_una_fuente_no_frena_a_la_otra(monkeypatch):
+    _settings(monkeypatch, {"steam_id64": "76561198000000000",
+                            "magic_cards": {"reference": "", "decklist": "1 Sol Ring"}})
+
+    def steam_roto(sid):
+        raise RuntimeError("Steam no deja leer el inventario (parece privado).")
+
+    monkeypatch.setattr(revalue.steam, "analyze", steam_roto)
+    monkeypatch.setattr(revalue.moxfield, "analyze",
+                        lambda reference=None, decklist=None:
+                        {"category": "Cartas Magic", "total": 5.0})
+    results, errors = revalue.refresh_live()
+    assert results == {"Cartas Magic": 5.0}
+    assert "privado" in errors["Skins CS:GO"]


### PR DESCRIPTION
## Problema

El WhatsApp del domingo repetía los mismos importes semana tras semana. Causa: `/api/monthly-summary` solo leía los snapshots de la base de datos, y esos snapshots **únicamente se escriben cuando se abre la web** (el frontend hace `POST /api/snapshot`) o al subir un PDF. El servidor nunca revalorizaba nada por sí mismo.

## Qué cambia

- **`sources/revalue.py` (nuevo)**: revalorización en vivo en el servidor de *Skins CS:GO* (Steam Market) y *Cartas Magic* (Scryfall) usando la configuración ya guardada (setting `steam_id64` y `magic_cards`). Guarda el snapshot del mes en curso.
  - Fuente sin configurar → se omite sin ruido.
  - Fuente configurada que falla → error visible; un 429 de Steam descarta el total parcial en vez de guardar un valor incompleto.
- **`/api/monthly-summary`**: refresca skins y cartas antes de componer el mensaje; los fallos de revalorización van como avisos ⚠️ dentro del propio WhatsApp (nunca se disfrazan con el valor antiguo).
- **`patrimonio.summary`**: el total pasa a usar el último valor conocido de cada categoría, y `category_months` recuerda de qué mes viene cada dato. En el mensaje, lo que no es del mes en curso sale marcado, p. ej. `• Liquidez (banco): 1.234,56 € (de 2026-06)`. Así el banco/TR no desaparecen del total ni fingen estar al día.
- **`static/app.js`**: la web restaura el resumen con la misma semántica (último valor por categoría) para no perder categorías cuando skins/cartas escriben en un mes nuevo.
- **Tests**: `test_revalue.py` (5 casos), arrastre por categoría y marcas de mes en `test_patrimonio.py`, y wiring del endpoint en `test_api.py`. Suite completa: 58 pasan.

## Estudio de APIs (`app/BANCOS_API.md`)

- **imagin (CaixaBank)**: sin API pública para particulares; el PSD2 directo (hub Redsys) exige licencia AISP. Vía recomendada: **Enable Banking** (soporta imagin explícitamente; modo *restricted production* gratuito para cuentas propias; consentimiento renovable cada 90/180 días). Alternativa: Wealth Reader (ya integrado, requiere API key comercial). GoCardless/Nordigen descartado (cerrado a altas nuevas).
- **Trade Republic**: sin API oficial. Vía práctica: **pytr** (websocket no oficial; login teléfono+PIN con device pairing; riesgo real de rotura/ToS y rate-limit del WAF desde mediados de 2026, con `tr-api` como alternativa). El PDF/CSV actual se mantiene como camino manual.

El documento incluye el plan de integración propuesto para ambas en PRs siguientes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TqUXD8a51c7UQei4nePy8x

---
_Generated by [Claude Code](https://claude.ai/code/session_01TqUXD8a51c7UQei4nePy8x)_